### PR TITLE
Add AI-ready issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/ai-ready.yml
+++ b/.github/ISSUE_TEMPLATE/ai-ready.yml
@@ -1,0 +1,108 @@
+name: "AI-Ready Issue"
+description: "Use this when you want the issue labeled 'AI ready' and scoped for an agent to pick up."
+title: "[AI ready] <short, specific title>"
+labels:
+  - "AI ready"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Fill this out so an agent can pick it up with minimal back-and-forth.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One sentence: what change are we making and why?
+      placeholder: "Implement X so that Y."
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Repo/path context, links, and any background.
+      placeholder: |
+        - Relevant paths:
+        - Related issues/PRs:
+        - Notes:
+
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What should be true when this is done?
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: Use checkboxes.
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: non_goals
+    attributes:
+      label: Non-goals / Out of scope
+      placeholder: "What this explicitly does not do."
+
+  - type: textarea
+    id: constraints
+    attributes:
+      label: Constraints / Guardrails (Do not)
+      description: Be explicit about unsafe areas.
+      placeholder: |
+        - Do not change database schema
+        - Do not modify auth flows
+        - Do not add new dependencies
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction Steps (bugs only)
+      description: If this is a bug, provide minimal repro.
+      placeholder: |
+        1) ...
+        2) ...
+
+        Expected:
+        Actual:
+
+  - type: textarea
+    id: verification
+    attributes:
+      label: Verification
+      description: How do we know it's correct? Include commands.
+      placeholder: |
+        Automated:
+        - `...`
+
+        Manual QA:
+        1) ...
+        2) ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: risk
+    attributes:
+      label: Risk / Rollback
+      placeholder: |
+        Risk:
+        Rollback:
+
+  - type: textarea
+    id: questions
+    attributes:
+      label: Questions to ask if blocked
+      placeholder: |
+        - ...


### PR DESCRIPTION
Adds a GitHub Issue Form that auto-applies the 'AI ready' label and provides a structured template for agent pickup.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a GitHub issue template only; no runtime code or production behavior changes.
> 
> **Overview**
> Adds a new GitHub Issue Form template (`.github/ISSUE_TEMPLATE/ai-ready.yml`) that auto-applies the `AI ready` label and pre-fills a structured set of required fields (summary, goal, acceptance criteria, constraints, verification) plus optional context, repro, risk/rollback, and blocker questions to better scope work for agent pickup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0266690d457fb9bce15b580bf8064e8fe409a098. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->