### PR TITLE
feat: Global exception handlers for database errors

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -1,8 +1,11 @@
+import logging
 import re
 from typing import Optional
 
 from fastapi import Depends, FastAPI, HTTPException, Query
-from sqlalchemy.exc import IntegrityError
+from fastapi.responses import JSONResponse
+from sqlalchemy.exc import DataError, IntegrityError, OperationalError
+from starlette.requests import Request
 from sqlmodel import Session, col, func, or_, select
 
 from app.db import get_session
@@ -23,6 +26,27 @@ from app.models import (
 )
 
 app = FastAPI(title="Breadcrumbs API")
+
+logger = logging.getLogger(__name__)
+
+
+@app.exception_handler(IntegrityError)
+def integrity_error_handler(request: Request, exc: IntegrityError):
+    logger.error("IntegrityError: %s", exc)
+    return JSONResponse(status_code=409, content={"detail": "Conflict: a database constraint was violated"})
+
+
+@app.exception_handler(OperationalError)
+def operational_error_handler(request: Request, exc: OperationalError):
+    logger.error("OperationalError: %s", exc)
+    return JSONResponse(status_code=503, content={"detail": "Service temporarily unavailable"})
+
+
+@app.exception_handler(DataError)
+def data_error_handler(request: Request, exc: DataError):
+    logger.error("DataError: %s", exc)
+    return JSONResponse(status_code=400, content={"detail": "Invalid data submitted"})
+
 
 THEME_UPDATABLE_FIELDS = {"body_md", "visibility"}
 

--- a/tests/test_exception_handlers.py
+++ b/tests/test_exception_handlers.py
@@ -1,0 +1,39 @@
+"""Tests for global database exception handlers."""
+
+from unittest.mock import patch
+
+from sqlalchemy.exc import DataError, IntegrityError, OperationalError
+
+
+def test_integrity_error_returns_409(client):
+    """IntegrityError from unhandled constraint violation returns 409."""
+    with patch(
+        "app.api.Session.get",
+        side_effect=IntegrityError("mock", {}, Exception("unique violation")),
+    ):
+        r = client.get("/themes/1")
+    assert r.status_code == 409
+    assert r.json()["detail"] == "Conflict: a database constraint was violated"
+    assert "SQL" not in r.json()["detail"]
+
+
+def test_operational_error_returns_503(client):
+    """OperationalError (e.g. connection failure) returns 503."""
+    with patch(
+        "app.api.Session.get",
+        side_effect=OperationalError("mock", {}, Exception("connection refused")),
+    ):
+        r = client.get("/themes/1")
+    assert r.status_code == 503
+    assert r.json()["detail"] == "Service temporarily unavailable"
+
+
+def test_data_error_returns_400(client):
+    """DataError (e.g. invalid column value) returns 400."""
+    with patch(
+        "app.api.Session.get",
+        side_effect=DataError("mock", {}, Exception("invalid input")),
+    ):
+        r = client.get("/themes/1")
+    assert r.status_code == 400
+    assert r.json()["detail"] == "Invalid data submitted"


### PR DESCRIPTION
## Summary
- Adds `@app.exception_handler()` for `IntegrityError` (409), `OperationalError` (503), and `DataError` (400)
- Structured JSON responses with `{"detail": "..."}` — no raw SQL exposed to clients
- Server-side logging via `logging.getLogger(__name__)`

Closes #8

## Test plan
- [x] `test_integrity_error_returns_409` — mocked constraint violation → 409
- [x] `test_operational_error_returns_503` — mocked connection failure → 503
- [x] `test_data_error_returns_400` — mocked invalid data → 400
- [x] All 83 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)