### PR TITLE
feat: Breadcrumb timestamps and separators in reader stream

### DIFF
--- a/frontend/src/components/theme-section.tsx
+++ b/frontend/src/components/theme-section.tsx
@@ -3,6 +3,7 @@ import { Link } from "@tanstack/react-router"
 import Markdown from "react-markdown"
 import { fetchBreadcrumbs } from "@/lib/api"
 import type { ThemePublic } from "@/lib/types"
+import { formatRelativeTime } from "@/lib/utils"
 
 interface ThemeSectionProps {
   theme: ThemePublic
@@ -33,10 +34,23 @@ export function ThemeSection({ theme }: ThemeSectionProps) {
       )}
 
       {breadcrumbs && breadcrumbs.length > 0 && (
-        <div className="space-y-2 pl-4">
-          {breadcrumbs.map((bc) => (
-            <div key={bc.id} className="prose prose-sm max-w-none">
-              <Markdown>{bc.body_md}</Markdown>
+        <div className="pl-4">
+          {breadcrumbs.map((bc, i) => (
+            <div key={bc.id}>
+              {i > 0 && (
+                <div className="flex justify-center py-2">
+                  <span className="text-muted-foreground/30 text-xs">·</span>
+                </div>
+              )}
+              <div className="prose prose-sm max-w-none">
+                <Markdown>{bc.body_md}</Markdown>
+              </div>
+              <time
+                dateTime={bc.created_at}
+                className="block text-[11px] text-muted-foreground/50 mt-1"
+              >
+                {formatRelativeTime(bc.created_at)}
+              </time>
             </div>
           ))}
         </div>

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -26,6 +26,27 @@ export function formatDateHeading(dateString: string): string {
   }).format(date)
 }
 
+/** Relative time for recent items, short date for older ones. */
+export function formatRelativeTime(dateString: string): string {
+  const date = new Date(dateString)
+  if (isNaN(date.getTime())) return dateString
+  const now = Date.now()
+  const diffMs = now - date.getTime()
+  const diffMins = Math.floor(diffMs / 60_000)
+  const diffHours = Math.floor(diffMs / 3_600_000)
+  const diffDays = Math.floor(diffMs / 86_400_000)
+
+  if (diffMins < 1) return "just now"
+  if (diffMins < 60) return `${diffMins}m ago`
+  if (diffHours < 24) return `${diffHours}h ago`
+  if (diffDays < 7) return `${diffDays}d ago`
+
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+  }).format(date)
+}
+
 /** Extract YYYY-MM-DD date key from an ISO datetime string. */
 export function dateKey(dateString: string): string {
   const date = new Date(dateString)


### PR DESCRIPTION
## Summary
- Adds relative time formatter (`formatRelativeTime`) — "just now", "5m ago", "3h ago", "2d ago", then "Jan 14" for older
- Shows faint timestamp below each breadcrumb in the reader stream
- Centered dot separator (`·`) between breadcrumbs for visual breathing room

Closes #21

## Test plan
- [x] TypeScript compiles clean (`npx tsc --noEmit`)
- [ ] Visual: breadcrumbs show relative timestamps below content
- [ ] Visual: dot separators appear between breadcrumbs (not before first)
- [ ] Timestamps transition from relative ("5m ago") to short date ("Jan 14") after 7 days

🤖 Generated with [Claude Code](https://claude.com/claude-code)