### PR TITLE
feat: Site header identity with tagline and meta

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,7 +6,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,opsz,wght@0,8..60,400;0,8..60,600;1,8..60,400&display=swap" rel="stylesheet" />
-    <title>Breadcrumbs</title>
+    <title>Breadcrumbs — a trail of small thoughts</title>
+    <meta name="description" content="A stream of small thoughts, observations, and notes organized into themes." />
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -83,13 +83,18 @@ function RootLayout() {
       <div className="min-h-screen bg-background text-foreground">
         <header className="border-b px-6 py-4">
           <div className="mx-auto max-w-3xl flex items-center justify-between">
-            <Link
-              to="/"
-              search={{}}
-              className="text-2xl font-bold no-underline text-foreground"
-            >
-              Breadcrumbs
-            </Link>
+            <div>
+              <Link
+                to="/"
+                search={{}}
+                className="text-2xl font-bold no-underline text-foreground"
+              >
+                Breadcrumbs
+              </Link>
+              <p className="text-sm italic text-muted-foreground">
+                a trail of small thoughts
+              </p>
+            </div>
             <div className="flex items-center gap-3">
               {!isWriterRoute && <SearchBar />}
               <Link
@@ -97,7 +102,7 @@ function RootLayout() {
                 className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground no-underline"
               >
                 <PenLine className="size-4" />
-                Writer
+                Write
               </Link>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Italic tagline beneath title: *a trail of small thoughts*
- `<title>` updated: "Breadcrumbs — a trail of small thoughts"
- `<meta description>` added for SEO/link previews
- "Writer" → "Write" in nav

Closes #26

## Test plan
- [x] TypeScript compiles clean
- [ ] Visual: tagline appears below title in header
- [ ] Tab title shows tagline
- [ ] Link preview shows description

🤖 Generated with [Claude Code](https://claude.com/claude-code)