### PR TITLE
feat: Retheme tag bar to understated text index

### DIFF
--- a/frontend/src/components/tag-bar.tsx
+++ b/frontend/src/components/tag-bar.tsx
@@ -1,6 +1,5 @@
 import { useQuery } from "@tanstack/react-query"
 import { Link } from "@tanstack/react-router"
-import { buttonVariants } from "@/components/ui/button"
 import { fetchTags } from "@/lib/api"
 import type { StreamSearch } from "@/lib/types"
 import { cn } from "@/lib/utils"
@@ -23,37 +22,34 @@ export function TagBar({ activeTag }: TagBarProps) {
   if (!tags || tags.length === 0) return null
 
   return (
-    <div className="flex flex-wrap gap-1.5">
+    <nav className="flex flex-wrap items-center gap-x-1 gap-y-1 text-sm text-muted-foreground">
       <Link
         to="/"
         search={(prev: StreamSearch) => ({ q: prev.q })}
         className={cn(
-          buttonVariants({
-            variant: activeTag ? "secondary" : "default",
-            size: "sm",
-          }),
-          "no-underline",
+          "no-underline hover:text-foreground transition-colors",
+          !activeTag ? "text-foreground font-medium underline underline-offset-4" : "",
         )}
       >
-        All
+        all
       </Link>
       {tags.map((tag) => (
-        <Link
-          key={tag.id}
-          to="/"
-          search={(prev: StreamSearch) => ({ q: prev.q, tag: tag.name })}
-          className={cn(
-            buttonVariants({
-              variant: activeTag === tag.name ? "default" : "secondary",
-              size: "sm",
-            }),
-            "no-underline",
-          )}
-        >
-          {tag.name}
-          <span className="ml-1 text-xs opacity-60">({tag.theme_count})</span>
-        </Link>
+        <span key={tag.id} className="contents">
+          <span className="text-muted-foreground/30 select-none">&middot;</span>
+          <Link
+            to="/"
+            search={(prev: StreamSearch) => ({ q: prev.q, tag: tag.name })}
+            className={cn(
+              "no-underline hover:text-foreground transition-colors",
+              activeTag === tag.name
+                ? "text-foreground font-medium underline underline-offset-4"
+                : "",
+            )}
+          >
+            {tag.name}
+          </Link>
+        </span>
       ))}
-    </div>
+    </nav>
   )
 }

--- a/frontend/src/components/theme-section.tsx
+++ b/frontend/src/components/theme-section.tsx
@@ -57,15 +57,15 @@ export function ThemeSection({ theme }: ThemeSectionProps) {
       )}
 
       {theme.tags.length > 0 && (
-        <div className="flex flex-wrap gap-1.5 pt-1">
+        <div className="flex flex-wrap gap-x-2 gap-y-1 pt-1">
           {theme.tags.map((tag) => (
             <Link
               key={tag.id}
               to="/"
               search={{ tag: tag.name }}
-              className="text-xs text-muted-foreground hover:text-foreground no-underline"
+              className="text-xs text-muted-foreground/70 hover:text-foreground no-underline transition-colors"
             >
-              {tag.name}
+              #{tag.name}
             </Link>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- Tag bar redesigned from button grid to plain text links with middot separators
- Active tag indicated by underline + medium weight (not filled button)
- Theme counts removed from tag bar
- Inline tags on themes prefixed with `#` and use muted warm tone
- Both presentations share consistent text-link visual language

Closes #22

## Test plan
- [x] TypeScript compiles clean
- [ ] Visual: tag bar shows "all · tag1 · tag2" as plain text
- [ ] Visual: active tag has underline
- [ ] Visual: inline tags show as "#tagname"
- [ ] Clicking tags still filters themes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)