### PR TITLE
feat: Nested breadcrumb tree UI

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -38,7 +38,8 @@
         "tw-animate-css": "^1.4.0",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.48.0",
-        "vite": "^7.3.1"
+        "vite": "^7.3.1",
+        "vitest": "^4.0.18"
       }
     },
     "node_modules/@antfu/ni": {
@@ -3635,6 +3636,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.18.tgz",
@@ -4343,6 +4351,17 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -4351,6 +4370,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -4743,6 +4769,117 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -4932,6 +5069,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ast-types": {
@@ -5179,6 +5326,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -5908,6 +6065,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -6191,6 +6355,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -6259,6 +6433,16 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -8856,6 +9040,17 @@
         "node": ">= 10"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -10116,6 +10311,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -10166,6 +10368,13 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -10175,6 +10384,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stdin-discarder": {
       "version": "0.2.2",
@@ -10385,6 +10601,13 @@
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
@@ -10410,6 +10633,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tldts": {
@@ -11021,6 +11254,84 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -11052,6 +11363,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,6 +40,7 @@
     "tw-animate-css": "^1.4.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.48.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.1",
+    "vitest": "^4.0.18"
   }
 }

--- a/frontend/src/components/theme-section.tsx
+++ b/frontend/src/components/theme-section.tsx
@@ -1,9 +1,11 @@
+import { useMemo } from "react"
 import { useQuery } from "@tanstack/react-query"
 import { Link } from "@tanstack/react-router"
 import Markdown from "react-markdown"
 import { fetchBreadcrumbs } from "@/lib/api"
 import { useScrollReveal } from "@/hooks/use-scroll-reveal"
-import type { BreadcrumbPublic, ThemePublic } from "@/lib/types"
+import { buildTree, type BreadcrumbNode } from "@/lib/tree"
+import type { ThemePublic } from "@/lib/types"
 import { cn, formatRelativeTime } from "@/lib/utils"
 
 interface ThemeSectionProps {
@@ -20,6 +22,11 @@ export function ThemeSection({ theme }: ThemeSectionProps) {
     queryFn: () => fetchBreadcrumbs(theme.id),
   })
 
+  const tree = useMemo(
+    () => (breadcrumbs ? buildTree(breadcrumbs) : []),
+    [breadcrumbs],
+  )
+
   return (
     <article className="space-y-3">
       <div className="prose prose-sm max-w-none">
@@ -34,10 +41,10 @@ export function ThemeSection({ theme }: ThemeSectionProps) {
         </p>
       )}
 
-      {breadcrumbs && breadcrumbs.length > 0 && (
+      {tree.length > 0 && (
         <div className="pl-4">
-          {breadcrumbs.map((bc, i) => (
-            <BreadcrumbEntry key={bc.id} bc={bc} showSeparator={i > 0} delay={i * 50} />
+          {tree.map((node, i) => (
+            <BreadcrumbTree key={node.id} node={node} depth={0} index={i} />
           ))}
         </div>
       )}
@@ -60,38 +67,44 @@ export function ThemeSection({ theme }: ThemeSectionProps) {
   )
 }
 
-function BreadcrumbEntry({
-  bc,
-  showSeparator,
-  delay,
+const INDENT_PX = [0, 16, 32, 48] as const
+
+function BreadcrumbTree({
+  node,
+  depth,
+  index,
 }: {
-  bc: BreadcrumbPublic
-  showSeparator: boolean
-  delay: number
+  node: BreadcrumbNode
+  depth: number
+  index: number
 }) {
   const { ref, revealed } = useScrollReveal<HTMLDivElement>()
+  const indent = INDENT_PX[Math.min(depth, 3)]
 
   return (
-    <div ref={ref}>
-      {showSeparator && (
+    <div ref={ref} style={indent > 0 ? { marginLeft: indent } : undefined}>
+      {depth === 0 && index > 0 && (
         <div className="flex justify-center py-2">
           <span className="text-muted-foreground/30 text-xs">·</span>
         </div>
       )}
       <div
         className={cn("opacity-0", revealed && "animate-fade-up")}
-        style={revealed ? { animationDelay: `${delay}ms` } : undefined}
+        style={revealed ? { animationDelay: `${index * 50}ms` } : undefined}
       >
         <div className="prose prose-sm max-w-none">
-          <Markdown>{bc.body_md}</Markdown>
+          <Markdown>{node.body_md}</Markdown>
         </div>
         <time
-          dateTime={bc.created_at}
+          dateTime={node.created_at}
           className="block text-[11px] text-muted-foreground/50 mt-1"
         >
-          {formatRelativeTime(bc.created_at)}
+          {formatRelativeTime(node.created_at)}
         </time>
       </div>
+      {node.children.map((child, i) => (
+        <BreadcrumbTree key={child.id} node={child} depth={depth + 1} index={i} />
+      ))}
     </div>
   )
 }

--- a/frontend/src/components/writer/add-breadcrumb-form.tsx
+++ b/frontend/src/components/writer/add-breadcrumb-form.tsx
@@ -1,15 +1,17 @@
 import { useEffect, useRef, useState } from "react"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
-import { Check, Plus } from "lucide-react"
+import { Check, Plus, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Textarea } from "@/components/ui/textarea"
 import { createBreadcrumb } from "@/lib/api"
 
 interface AddBreadcrumbFormProps {
   themeId: number
+  parentId?: number
+  onCancel?: () => void
 }
 
-export function AddBreadcrumbForm({ themeId }: AddBreadcrumbFormProps) {
+export function AddBreadcrumbForm({ themeId, parentId, onCancel }: AddBreadcrumbFormProps) {
   const queryClient = useQueryClient()
   const [bodyMd, setBodyMd] = useState("")
   const [showSaved, setShowSaved] = useState(false)
@@ -24,7 +26,8 @@ export function AddBreadcrumbForm({ themeId }: AddBreadcrumbFormProps) {
   }, [])
 
   const mutation = useMutation({
-    mutationFn: (data: { body_md: string }) => createBreadcrumb(themeId, data),
+    mutationFn: (data: { body_md: string; parent_id?: number }) =>
+      createBreadcrumb(themeId, data),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: ["themes", themeId, "breadcrumbs"],
@@ -33,14 +36,20 @@ export function AddBreadcrumbForm({ themeId }: AddBreadcrumbFormProps) {
       setShowSaved(true)
       if (savedTimer.current) clearTimeout(savedTimer.current)
       savedTimer.current = setTimeout(() => setShowSaved(false), 2000)
-      // Refocus for rapid-fire entry
-      textareaRef.current?.focus()
+      if (parentId) {
+        onCancel?.()
+      } else {
+        textareaRef.current?.focus()
+      }
     },
   })
 
   function submit() {
     if (!bodyMd.trim() || mutation.isPending) return
-    mutation.mutate({ body_md: bodyMd.trim() })
+    mutation.mutate({
+      body_md: bodyMd.trim(),
+      ...(parentId ? { parent_id: parentId } : {}),
+    })
   }
 
   function handleSubmit(e: React.FormEvent) {
@@ -53,6 +62,9 @@ export function AddBreadcrumbForm({ themeId }: AddBreadcrumbFormProps) {
       e.preventDefault()
       submit()
     }
+    if (e.key === "Escape" && onCancel) {
+      onCancel()
+    }
   }
 
   return (
@@ -62,8 +74,9 @@ export function AddBreadcrumbForm({ themeId }: AddBreadcrumbFormProps) {
         value={bodyMd}
         onChange={(e) => setBodyMd(e.target.value)}
         onKeyDown={handleKeyDown}
-        placeholder="Add a breadcrumb... (supports markdown)"
-        rows={3}
+        placeholder={parentId ? "Reply..." : "Add a breadcrumb... (supports markdown)"}
+        rows={parentId ? 2 : 3}
+        autoFocus={!!parentId}
       />
       {mutation.error && (
         <p className="text-sm text-destructive">{mutation.error.message}</p>
@@ -75,8 +88,14 @@ export function AddBreadcrumbForm({ themeId }: AddBreadcrumbFormProps) {
           disabled={mutation.isPending || !bodyMd.trim()}
         >
           <Plus className="size-4" />
-          {mutation.isPending ? "Adding..." : "Add Breadcrumb"}
+          {mutation.isPending ? "Adding..." : parentId ? "Reply" : "Add Breadcrumb"}
         </Button>
+        {onCancel && (
+          <Button type="button" size="sm" variant="outline" onClick={onCancel}>
+            <X className="size-4" />
+            Cancel
+          </Button>
+        )}
         {showSaved && (
           <span className="text-sm text-muted-foreground flex items-center gap-1 animate-in fade-in">
             <Check className="size-3.5" />
@@ -84,9 +103,11 @@ export function AddBreadcrumbForm({ themeId }: AddBreadcrumbFormProps) {
           </span>
         )}
       </div>
-      <p className="text-xs text-muted-foreground">
-        Enter to save &middot; Shift+Enter for new line
-      </p>
+      {!parentId && (
+        <p className="text-xs text-muted-foreground">
+          Enter to save &middot; Shift+Enter for new line
+        </p>
+      )}
     </form>
   )
 }

--- a/frontend/src/components/writer/breadcrumb-item.tsx
+++ b/frontend/src/components/writer/breadcrumb-item.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
-import { Pencil, Trash2, Check, X } from "lucide-react"
+import { Pencil, Trash2, Check, X, MessageSquare } from "lucide-react"
 import Markdown from "react-markdown"
 import { Button } from "@/components/ui/button"
 import { Textarea } from "@/components/ui/textarea"
@@ -16,29 +16,34 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog"
 import { updateBreadcrumb, deleteBreadcrumb } from "@/lib/api"
-import type { BreadcrumbPublic } from "@/lib/types"
+import { AddBreadcrumbForm } from "./add-breadcrumb-form"
+import type { BreadcrumbNode } from "@/lib/tree"
 import { formatDate } from "@/lib/utils"
 
+const INDENT_PX = [0, 16, 32, 48] as const
+
 interface BreadcrumbItemProps {
-  breadcrumb: BreadcrumbPublic
+  node: BreadcrumbNode
   themeId: number
+  depth?: number
 }
 
-export function BreadcrumbItem({ breadcrumb, themeId }: BreadcrumbItemProps) {
+export function BreadcrumbItem({ node, themeId, depth = 0 }: BreadcrumbItemProps) {
   const queryClient = useQueryClient()
   const [editing, setEditing] = useState(false)
-  const [bodyMd, setBodyMd] = useState(breadcrumb.body_md)
+  const [replying, setReplying] = useState(false)
+  const [bodyMd, setBodyMd] = useState(node.body_md)
 
   // Sync local state when prop changes (e.g. after mutation + refetch)
   useEffect(() => {
     if (!editing) {
-      setBodyMd(breadcrumb.body_md)
+      setBodyMd(node.body_md)
     }
-  }, [breadcrumb.body_md, editing])
+  }, [node.body_md, editing])
 
   const editMutation = useMutation({
     mutationFn: (data: { body_md: string }) =>
-      updateBreadcrumb(themeId, breadcrumb.id, data),
+      updateBreadcrumb(themeId, node.id, data),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: ["themes", themeId, "breadcrumbs"],
@@ -48,7 +53,7 @@ export function BreadcrumbItem({ breadcrumb, themeId }: BreadcrumbItemProps) {
   })
 
   const removeMutation = useMutation({
-    mutationFn: () => deleteBreadcrumb(themeId, breadcrumb.id),
+    mutationFn: () => deleteBreadcrumb(themeId, node.id),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: ["themes", themeId, "breadcrumbs"],
@@ -62,13 +67,16 @@ export function BreadcrumbItem({ breadcrumb, themeId }: BreadcrumbItemProps) {
   }
 
   function handleCancel() {
-    setBodyMd(breadcrumb.body_md)
+    setBodyMd(node.body_md)
     setEditing(false)
   }
 
+  const indent = INDENT_PX[Math.min(depth, 3)]
+  const hasChildren = node.children.length > 0
+
   if (editing) {
     return (
-      <div className="rounded-lg border p-3 space-y-3">
+      <div className="rounded-lg border p-3 space-y-3" style={indent > 0 ? { marginLeft: indent } : undefined}>
         <Textarea
           value={bodyMd}
           onChange={(e) => setBodyMd(e.target.value)}
@@ -105,56 +113,81 @@ export function BreadcrumbItem({ breadcrumb, themeId }: BreadcrumbItemProps) {
   }
 
   return (
-    <div className="group rounded-lg border p-3 space-y-1">
-      <div className="flex items-start justify-between gap-2">
-        <div className="prose prose-sm max-w-none flex-1">
-          <Markdown>{breadcrumb.body_md}</Markdown>
+    <>
+      <div className="group rounded-lg border p-3 space-y-1" style={indent > 0 ? { marginLeft: indent } : undefined}>
+        <div className="flex items-start justify-between gap-2">
+          <div className="prose prose-sm max-w-none flex-1">
+            <Markdown>{node.body_md}</Markdown>
+          </div>
+          <div className="flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity shrink-0">
+            <Button
+              size="icon-xs"
+              variant="ghost"
+              onClick={() => setReplying(!replying)}
+              title="Reply"
+            >
+              <MessageSquare className="size-3.5" />
+            </Button>
+            <Button
+              size="icon-xs"
+              variant="ghost"
+              onClick={() => setEditing(true)}
+            >
+              <Pencil className="size-3.5" />
+            </Button>
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button
+                  size="icon-xs"
+                  variant="ghost"
+                  disabled={removeMutation.isPending}
+                >
+                  <Trash2 className="size-3.5" />
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Delete breadcrumb?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    {hasChildren
+                      ? "This will delete this breadcrumb and all its replies. This action cannot be undone."
+                      : "This will permanently delete this breadcrumb. This action cannot be undone."}
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction onClick={() => removeMutation.mutate()}>
+                    Delete
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          </div>
         </div>
-        <div className="flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity shrink-0">
-          <Button
-            size="icon-xs"
-            variant="ghost"
-            onClick={() => setEditing(true)}
-          >
-            <Pencil className="size-3.5" />
-          </Button>
-          <AlertDialog>
-            <AlertDialogTrigger asChild>
-              <Button
-                size="icon-xs"
-                variant="ghost"
-                disabled={removeMutation.isPending}
-              >
-                <Trash2 className="size-3.5" />
-              </Button>
-            </AlertDialogTrigger>
-            <AlertDialogContent>
-              <AlertDialogHeader>
-                <AlertDialogTitle>Delete breadcrumb?</AlertDialogTitle>
-                <AlertDialogDescription>
-                  This will permanently delete this breadcrumb. This action
-                  cannot be undone.
-                </AlertDialogDescription>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogCancel>Cancel</AlertDialogCancel>
-                <AlertDialogAction onClick={() => removeMutation.mutate()}>
-                  Delete
-                </AlertDialogAction>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
-        </div>
+        <time className="block text-xs text-muted-foreground">
+          {formatDate(node.created_at)}
+          {node.updated_at && <> &middot; edited</>}
+        </time>
+        {removeMutation.error && (
+          <p className="text-sm text-destructive">
+            {removeMutation.error.message}
+          </p>
+        )}
       </div>
-      <time className="block text-xs text-muted-foreground">
-        {formatDate(breadcrumb.created_at)}
-        {breadcrumb.updated_at && <> &middot; edited</>}
-      </time>
-      {removeMutation.error && (
-        <p className="text-sm text-destructive">
-          {removeMutation.error.message}
-        </p>
+
+      {replying && (
+        <div style={{ marginLeft: INDENT_PX[Math.min(depth + 1, 3)] }} className="mt-2">
+          <AddBreadcrumbForm
+            themeId={themeId}
+            parentId={node.id}
+            onCancel={() => setReplying(false)}
+          />
+        </div>
       )}
-    </div>
+
+      {node.children.map((child) => (
+        <BreadcrumbItem key={child.id} node={child} themeId={themeId} depth={depth + 1} />
+      ))}
+    </>
   )
 }

--- a/frontend/src/lib/__tests__/tree.test.ts
+++ b/frontend/src/lib/__tests__/tree.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest"
+import { buildTree } from "../tree"
+import type { BreadcrumbPublic } from "../types"
+
+function bc(id: number, parentId: number | null = null): BreadcrumbPublic {
+  return {
+    id,
+    body_md: `breadcrumb ${id}`,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: null,
+    parent_id: parentId,
+  }
+}
+
+describe("buildTree", () => {
+  it("returns empty array for empty input", () => {
+    expect(buildTree([])).toEqual([])
+  })
+
+  it("returns all items as roots when no parent_id set", () => {
+    const result = buildTree([bc(1), bc(2), bc(3)])
+    expect(result).toHaveLength(3)
+    expect(result.every((n) => n.children.length === 0)).toBe(true)
+  })
+
+  it("nests child under parent", () => {
+    const result = buildTree([bc(1), bc(2, 1)])
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe(1)
+    expect(result[0].children).toHaveLength(1)
+    expect(result[0].children[0].id).toBe(2)
+  })
+
+  it("handles multi-level nesting", () => {
+    const result = buildTree([bc(1), bc(2, 1), bc(3, 2)])
+    expect(result).toHaveLength(1)
+    expect(result[0].children[0].children[0].id).toBe(3)
+  })
+
+  it("handles multiple roots with children", () => {
+    const result = buildTree([bc(1), bc(2), bc(3, 1), bc(4, 2)])
+    expect(result).toHaveLength(2)
+    expect(result[0].children).toHaveLength(1)
+    expect(result[1].children).toHaveLength(1)
+  })
+
+  it("treats orphans as roots", () => {
+    const result = buildTree([bc(1), bc(2, 999)])
+    expect(result).toHaveLength(2)
+  })
+})

--- a/frontend/src/lib/tree.ts
+++ b/frontend/src/lib/tree.ts
@@ -1,0 +1,37 @@
+import type { BreadcrumbPublic } from "./types"
+
+export interface BreadcrumbNode extends BreadcrumbPublic {
+  children: BreadcrumbNode[]
+}
+
+/**
+ * Convert a flat list of breadcrumbs (with parent_id) into a tree.
+ * Preserves chronological order from the API.
+ * Orphans (parent_id points to missing breadcrumb) are treated as roots.
+ */
+export function buildTree(breadcrumbs: BreadcrumbPublic[]): BreadcrumbNode[] {
+  const nodeMap = new Map<number, BreadcrumbNode>()
+  const roots: BreadcrumbNode[] = []
+
+  // First pass: create nodes
+  for (const bc of breadcrumbs) {
+    nodeMap.set(bc.id, { ...bc, children: [] })
+  }
+
+  // Second pass: link children to parents
+  for (const bc of breadcrumbs) {
+    const node = nodeMap.get(bc.id)!
+    if (bc.parent_id != null) {
+      const parent = nodeMap.get(bc.parent_id)
+      if (parent) {
+        parent.children.push(node)
+      } else {
+        roots.push(node) // orphan — treat as root
+      }
+    } else {
+      roots.push(node)
+    }
+  }
+
+  return roots
+}

--- a/frontend/src/routes/writer/themes.$themeId.tsx
+++ b/frontend/src/routes/writer/themes.$themeId.tsx
@@ -1,6 +1,8 @@
+import { useMemo } from "react"
 import { createFileRoute, Link } from "@tanstack/react-router"
 import { useQuery } from "@tanstack/react-query"
 import { fetchTheme, fetchBreadcrumbs } from "@/lib/api"
+import { buildTree } from "@/lib/tree"
 import { ThemeHeaderEditor } from "@/components/writer/theme-header-editor"
 import { BreadcrumbItem } from "@/components/writer/breadcrumb-item"
 import { AddBreadcrumbForm } from "@/components/writer/add-breadcrumb-form"
@@ -66,6 +68,11 @@ function ThemeEditor() {
     )
   }
 
+  const tree = useMemo(
+    () => (breadcrumbs ? buildTree(breadcrumbs) : []),
+    [breadcrumbs],
+  )
+
   if (!theme) return null
 
   return (
@@ -98,10 +105,10 @@ function ThemeEditor() {
           </p>
         )}
 
-        {breadcrumbs && breadcrumbs.length > 0 && (
+        {tree.length > 0 && (
           <div className="space-y-3">
-            {breadcrumbs.map((bc) => (
-              <BreadcrumbItem key={bc.id} breadcrumb={bc} themeId={id} />
+            {tree.map((node) => (
+              <BreadcrumbItem key={node.id} node={node} themeId={id} />
             ))}
           </div>
         )}


### PR DESCRIPTION
## Summary
- **Tree builder** (`frontend/src/lib/tree.ts`): converts flat API list to nested tree using `parent_id`
- **Reader view**: nested breadcrumbs render with indentation (capped at 3 visual levels), dot separators between top-level siblings only
- **Writer view**: Reply button (speech bubble icon) on each breadcrumb, inline reply form with parent_id, children rendered nested below parent
- **Delete dialog**: warns "This will delete this breadcrumb and all its replies" when breadcrumb has children
- **Tests**: 6 Vitest unit tests for `buildTree` (empty, flat, nested, multi-level, orphan handling)
- `useMemo` around `buildTree()` calls for render performance

Closes #27

## Test plan
- [x] TypeScript compiles clean (`npx tsc --noEmit`)
- [x] Vitest: 6 tree builder tests pass
- [x] Backend: 83 tests pass
- [ ] Visual: reader shows nested breadcrumbs indented under parents
- [ ] Visual: writer Reply button → inline form → child appears nested
- [ ] Visual: delete parent with children → cascade warning in dialog
- [ ] Visual: indent caps at 3 levels visually

🤖 Generated with [Claude Code](https://claude.com/claude-code)