### PR TITLE
feat: About page, log entry 003, roadmap aspirations

### DIFF
--- a/docs/log/003-the-clay-keeps-bending.md
+++ b/docs/log/003-the-clay-keeps-bending.md
@@ -1,0 +1,30 @@
+# 003 — The Clay Keeps Bending
+
+**Date:** 2026-02-12
+**Dimensions:** Product Strategy, Architecture
+
+---
+
+## What happened
+
+Seven issues closed in one session. Sidebar layout, nested tree UI, scroll animations, empty states, tag restyling, timestamps, exception handlers. Each one a small reshaping. None of them required a plan longer than a paragraph. The metaphor from entry 002 — software as clay — held up under real load.
+
+## The deeper insight
+
+Building software is like molding clay. As long as the material is shaped such that it is structurally sound, the possibilities are vast and the material is very forgiving. That's the sentence I want to remember. It's not that you can do anything — you can't violate structural integrity. But within the constraints of soundness, the reshaping is nearly free. And with agents, the reshaping speed is fast enough that you can think *through* the material rather than *about* it.
+
+## What's emerging
+
+Three aspirations crystallized during this session:
+
+**Voice input.** I want to add breadcrumbs by talking to my phone. My agent Larry can broker the conversation — I speak a thought, Larry shapes it into a breadcrumb, and it lands on the site. The input surface should be as casual as the format.
+
+**Project log funneling.** As I work through units of work across my projects and log reflections, those reflections should funnel into breadcrumbs automatically. The learning journal entries I write after each PR — those are breadcrumbs. They should flow into the stream without manual re-entry.
+
+**A chat bot that knows me.** Each breadcrumb teaches it something. Over time, it becomes a representation of how I think — what I've built, what I've learned, what patterns I reach for. Someone could ask it whether a role is a good fit, or what my take on a technical problem would be. The About page is where it'll live.
+
+## The takeaway
+
+Breadcrumbs started as a blog. It's becoming an input/output system for my thinking. The blog is one output surface. Voice is one input surface. The chat bot is another output surface. The breadcrumbs themselves are the substrate — small, atomic, accretive. Each one makes the system a little smarter about who I am.
+
+The About page we built today is sparse on purpose. It's a placeholder for the chat window that's coming. Right now it says "eventually, these breadcrumbs will learn to talk back." That's the plan.

--- a/docs/log/README.md
+++ b/docs/log/README.md
@@ -16,6 +16,7 @@ Each entry captures what was built, what was learned, and the product thinking b
 |---|------|-------|------------|
 | [001](001-prototype-worth-a-thousand-meetings.md) | 2026-02-09 | A Prototype Is Worth a Thousand Meetings | Process & Tooling, Product Strategy |
 | [002](002-clay-not-blueprints.md) | 2026-02-09 | Clay, Not Blueprints | Product Strategy, UX Design |
+| [003](003-the-clay-keeps-bending.md) | 2026-02-12 | The Clay Keeps Bending | Product Strategy, Architecture |
 
 ---
 
@@ -25,9 +26,9 @@ Tracking breadth across the full product-building journey.
 
 | Dimension | Description | Entries |
 |-----------|-------------|---------|
-| Product Strategy | Why build this? User needs, prioritization | 001, 002 |
+| Product Strategy | Why build this? User needs, prioritization | 001, 002, 003 |
 | UX Design | Interaction patterns, user psychology, affordances | 002 |
-| Architecture | System design, data modeling, scaling trade-offs | — |
+| Architecture | System design, data modeling, scaling trade-offs | 003 |
 | Frontend | React/TanStack patterns, state, performance | — |
 | Backend | API design, database, service layer patterns | — |
 | DevOps | CI/CD, deployment, infrastructure, monitoring | — |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -34,11 +34,21 @@ pagination. 70 total tests.
 
 ## Post-MVP
 
+### UI Polish
 - Date nav sidebar — sticky left-column date navigator that highlights the current date section as the user scrolls, with forward/backward time navigation
 - Tag search — search/filter within the tag sidebar as the list grows
-- Real authentication (OAuth/JWT)
 - Markdown preview in editor
 - Tag autocomplete
 - Image upload
+
+### Infrastructure
+- Real authentication (OAuth/JWT)
 - RSS feed
 - Social sharing
+
+### Input Surfaces
+- Voice input — add breadcrumbs by talking to phone via Larry (agent-mediated voice capture)
+- Project log funneling — post-PR learning journal entries auto-flow into breadcrumbs as new themes/crumbs
+
+### Output Surfaces
+- Chat bot on About page — trained on breadcrumbs, represents how I think; visitors can ask it questions about me, my work, or whether a role is a good fit

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -9,12 +9,18 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as AboutRouteImport } from './routes/about'
 import { Route as WriterRouteRouteImport } from './routes/writer/route'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as WriterIndexRouteImport } from './routes/writer/index'
 import { Route as WriterThemesThemeIdRouteImport } from './routes/writer/themes.$themeId'
 import { Route as TagsTagNameThemesRouteImport } from './routes/tags.$tagName.themes'
 
+const AboutRoute = AboutRouteImport.update({
+  id: '/about',
+  path: '/about',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const WriterRouteRoute = WriterRouteRouteImport.update({
   id: '/writer',
   path: '/writer',
@@ -44,12 +50,14 @@ const TagsTagNameThemesRoute = TagsTagNameThemesRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/writer': typeof WriterRouteRouteWithChildren
+  '/about': typeof AboutRoute
   '/writer/': typeof WriterIndexRoute
   '/tags/$tagName/themes': typeof TagsTagNameThemesRoute
   '/writer/themes/$themeId': typeof WriterThemesThemeIdRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/about': typeof AboutRoute
   '/writer': typeof WriterIndexRoute
   '/tags/$tagName/themes': typeof TagsTagNameThemesRoute
   '/writer/themes/$themeId': typeof WriterThemesThemeIdRoute
@@ -58,6 +66,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/writer': typeof WriterRouteRouteWithChildren
+  '/about': typeof AboutRoute
   '/writer/': typeof WriterIndexRoute
   '/tags/$tagName/themes': typeof TagsTagNameThemesRoute
   '/writer/themes/$themeId': typeof WriterThemesThemeIdRoute
@@ -67,15 +76,22 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/writer'
+    | '/about'
     | '/writer/'
     | '/tags/$tagName/themes'
     | '/writer/themes/$themeId'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/writer' | '/tags/$tagName/themes' | '/writer/themes/$themeId'
+  to:
+    | '/'
+    | '/about'
+    | '/writer'
+    | '/tags/$tagName/themes'
+    | '/writer/themes/$themeId'
   id:
     | '__root__'
     | '/'
     | '/writer'
+    | '/about'
     | '/writer/'
     | '/tags/$tagName/themes'
     | '/writer/themes/$themeId'
@@ -84,11 +100,19 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   WriterRouteRoute: typeof WriterRouteRouteWithChildren
+  AboutRoute: typeof AboutRoute
   TagsTagNameThemesRoute: typeof TagsTagNameThemesRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/about': {
+      id: '/about'
+      path: '/about'
+      fullPath: '/about'
+      preLoaderRoute: typeof AboutRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/writer': {
       id: '/writer'
       path: '/writer'
@@ -144,6 +168,7 @@ const WriterRouteRouteWithChildren = WriterRouteRoute._addFileChildren(
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   WriterRouteRoute: WriterRouteRouteWithChildren,
+  AboutRoute: AboutRoute,
   TagsTagNameThemesRoute: TagsTagNameThemesRoute,
 }
 export const routeTree = rootRouteImport

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -98,6 +98,12 @@ function RootLayout() {
             <div className="flex items-center gap-3">
               {!isWriterRoute && <SearchBar />}
               <Link
+                to="/about"
+                className="text-sm text-muted-foreground hover:text-foreground no-underline"
+              >
+                About
+              </Link>
+              <Link
                 to="/writer"
                 className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground no-underline"
               >

--- a/frontend/src/routes/about.tsx
+++ b/frontend/src/routes/about.tsx
@@ -1,0 +1,47 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+export const Route = createFileRoute("/about")({
+  component: About,
+})
+
+function About() {
+  return (
+    <div className="max-w-2xl mx-auto space-y-6">
+      <h1 className="text-2xl font-bold tracking-tight">About</h1>
+
+      <div className="prose prose-sm max-w-none space-y-4">
+        <p>
+          I'm Brandon. I build things and think about building things, which
+          sometimes feels like the same activity. I'm also interested in
+          consciousness and mind, football (which Americans call soccer),
+          music, dance, and how human beings come back together. To name a
+          few. All of it shows up here.
+        </p>
+        <p>
+          Breadcrumbs is where I drop the small thoughts that fall out of
+          all of that — observations, questions, half-formed ideas — before
+          they evaporate. Think of it less like a blog and more like a
+          notebook left open on the table. Not essays. Not tutorials. Just
+          crumbs, organized into themes, dropped along the way.
+        </p>
+        <p>
+          The format is inspired in part by Alex Komoroske's{" "}
+          <a
+            href="https://docs.google.com/document/d/1x8z6k07JqXTVIRVNr1S_7wYVl5L7IpX14gXxU1UBrGk/edit"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Bits and Bobs
+          </a>
+          {" "}— the idea that the interesting thoughts rarely arrive fully
+          formed. They start as fragments. If you collect enough of them in
+          one place, patterns emerge that you couldn't have planned.
+        </p>
+        <p className="text-muted-foreground italic">
+          Eventually, these breadcrumbs will learn to talk back. For now,
+          you're stuck reading.
+        </p>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- New `/about` route with short bio, interests (consciousness, football, music, dance), Alex Komoroske's Bits and Bobs attribution, and teaser for future chat bot
- About link added to header nav
- Log entry 003: "The Clay Keeps Bending" — deepens clay metaphor, documents three aspirations (voice input, project log funneling, chat bot)
- Roadmap reorganized Post-MVP into: UI Polish, Infrastructure, Input Surfaces, Output Surfaces

## Test plan
- [ ] `/about` route renders correctly
- [ ] About link visible in header nav
- [ ] Bits and Bobs link opens in new tab
- [ ] Log entry 003 renders in markdown
- [ ] Log README index updated with entry 003

🤖 Generated with [Claude Code](https://claude.com/claude-code)