### PR TITLE
Fix: Extend JWT expiration to 30 days

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -11,7 +11,7 @@ load_dotenv()
 ADMIN_PASSWORD = os.getenv("ADMIN_PASSWORD", "")
 JWT_SECRET = os.getenv("JWT_SECRET", "")
 JWT_ALGORITHM = "HS256"
-JWT_EXPIRATION_HOURS = 24
+JWT_EXPIRATION_HOURS = 24 * 30
 
 
 def verify_admin_password(password: str) -> bool:


### PR DESCRIPTION
## Summary
- Extends JWT expiration from 24 hours to 30 days for the single-admin blog
- `localStorage` already persists across browser closes — the short token lifetime was the only cause of re-auth

Closes #42

## Test plan
- [ ] Log in, verify token works
- [ ] Close browser, reopen — still authenticated
- [ ] After 30 days (or manually set short expiry to test), confirm 401 redirect works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends admin JWT lifetime from 24 hours to 30 days, increasing exposure if a token is leaked but otherwise a small, localized change.
> 
> **Overview**
> Extends admin JWT validity by changing `JWT_EXPIRATION_HOURS` from `24` to `24 * 30`, so `create_access_token()` issues tokens that last ~30 days instead of 1 day.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e3177e419f2f9e313fb72ae100be21477dbfbbd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->