### PR TITLE
feat: Mobile tag discovery with bottom sheet

### DIFF
--- a/frontend/src/components/tag-bar.tsx
+++ b/frontend/src/components/tag-bar.tsx
@@ -2,11 +2,13 @@ import { useMemo, useState } from "react"
 import { useQuery } from "@tanstack/react-query"
 import { Link } from "@tanstack/react-router"
 import { fetchTags } from "@/lib/api"
-import type { StreamSearch } from "@/lib/types"
+import type { StreamSearch, TagWithCount } from "@/lib/types"
 import { cn } from "@/lib/utils"
 import { Input } from "@/components/ui/input"
+import { TagSheet } from "@/components/tag-sheet"
 
 const VISIBLE_COUNT = 15
+const MOBILE_VISIBLE_COUNT = 12
 
 interface TagBarProps {
   activeTag?: string
@@ -76,6 +78,76 @@ export function TagBar({ activeTag, horizontal = false }: TagBarProps) {
 
   if (horizontal) {
     return (
+      <HorizontalTagBar
+        sortedTags={sortedTags}
+        activeTag={activeTag}
+      />
+    )
+  }
+
+  return (
+    <VerticalTagList
+      sortedTags={sortedTags}
+      maxCount={maxCount}
+      activeTag={activeTag}
+    />
+  )
+}
+
+function TagPill({
+  tag,
+  isActive,
+}: {
+  tag: TagWithCount
+  isActive: boolean
+}) {
+  return (
+    <Link
+      to="/"
+      search={(prev: StreamSearch) => ({ q: prev.q, tag: tag.name })}
+      aria-label={`${tag.name}, ${tag.theme_count} ${tag.theme_count === 1 ? "theme" : "themes"}`}
+      aria-current={isActive ? "page" : undefined}
+      className={cn(
+        "shrink-0 rounded-full px-3 py-1.5 no-underline transition-colors whitespace-nowrap",
+        isActive
+          ? "bg-foreground text-background font-medium"
+          : "bg-secondary text-muted-foreground hover:text-foreground",
+      )}
+    >
+      {tag.name}
+    </Link>
+  )
+}
+
+function HorizontalTagBar({
+  sortedTags,
+  activeTag,
+}: {
+  sortedTags: TagWithCount[]
+  activeTag?: string
+}) {
+  const [sheetOpen, setSheetOpen] = useState(false)
+
+  const needsTruncation = sortedTags.length > MOBILE_VISIBLE_COUNT
+  const activeIndex = sortedTags.findIndex((t) => t.name === activeTag)
+  const activeInHidden = needsTruncation && activeIndex >= MOBILE_VISIBLE_COUNT
+
+  let mobileTags: TagWithCount[]
+  if (!needsTruncation) {
+    mobileTags = sortedTags
+  } else if (activeInHidden) {
+    mobileTags = [
+      ...sortedTags.slice(0, MOBILE_VISIBLE_COUNT - 1),
+      sortedTags[activeIndex],
+    ]
+  } else {
+    mobileTags = sortedTags.slice(0, MOBILE_VISIBLE_COUNT)
+  }
+
+  const hiddenCount = sortedTags.length - mobileTags.length
+
+  return (
+    <>
       <nav className="flex gap-2 overflow-x-auto pb-2 scrollbar-none text-sm">
         <Link
           to="/"
@@ -90,43 +162,29 @@ export function TagBar({ activeTag, horizontal = false }: TagBarProps) {
         >
           All
         </Link>
-        {sortedTags.map((tag) => {
-          const isActive = activeTag === tag.name
-          return (
-            <Link
-              key={tag.id}
-              to="/"
-              search={(prev: StreamSearch) => ({ q: prev.q, tag: tag.name })}
-              aria-label={`${tag.name}, ${tag.theme_count} ${tag.theme_count === 1 ? "theme" : "themes"}`}
-              aria-current={isActive ? "page" : undefined}
-              className={cn(
-                "shrink-0 rounded-full px-3 py-1.5 no-underline transition-colors whitespace-nowrap",
-                isActive
-                  ? "bg-foreground text-background font-medium"
-                  : "bg-secondary text-muted-foreground hover:text-foreground",
-              )}
-            >
-              {tag.name}
-            </Link>
-          )
-        })}
+        {mobileTags.map((tag) => (
+          <TagPill key={tag.id} tag={tag} isActive={activeTag === tag.name} />
+        ))}
+        {hiddenCount > 0 && (
+          <button
+            type="button"
+            onClick={() => setSheetOpen(true)}
+            className="shrink-0 rounded-full px-3 py-1.5 text-sm whitespace-nowrap bg-secondary text-muted-foreground hover:text-foreground transition-colors border border-dashed border-border cursor-pointer"
+          >
+            +{hiddenCount} more
+          </button>
+        )}
       </nav>
-    )
-  }
-
-  return (
-    <VerticalTagList
-      sortedTags={sortedTags}
-      maxCount={maxCount}
-      activeTag={activeTag}
-    />
+      {needsTruncation && (
+        <TagSheet
+          open={sheetOpen}
+          onOpenChange={setSheetOpen}
+          sortedTags={sortedTags}
+          activeTag={activeTag}
+        />
+      )}
+    </>
   )
-}
-
-interface TagWithCount {
-  id: number
-  name: string
-  theme_count: number
 }
 
 function TagLink({

--- a/frontend/src/components/tag-sheet.tsx
+++ b/frontend/src/components/tag-sheet.tsx
@@ -1,0 +1,217 @@
+import { useMemo, useState } from "react"
+import { Link } from "@tanstack/react-router"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import type { StreamSearch, TagWithCount } from "@/lib/types"
+import { cn } from "@/lib/utils"
+
+const POPULAR_COUNT = 10
+const SEARCH_THRESHOLD = 40
+
+interface TagSheetProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  sortedTags: TagWithCount[]
+  activeTag?: string
+}
+
+export function TagSheet({
+  open,
+  onOpenChange,
+  sortedTags,
+  activeTag,
+}: TagSheetProps) {
+  const [filter, setFilter] = useState("")
+
+  const showSearch = sortedTags.length >= SEARCH_THRESHOLD
+
+  const popularTags = useMemo(
+    () => sortedTags.slice(0, POPULAR_COUNT),
+    [sortedTags],
+  )
+
+  const alphabeticalTags = useMemo(
+    () => [...sortedTags].sort((a, b) => a.name.localeCompare(b.name)),
+    [sortedTags],
+  )
+
+  const filteredTags = filter
+    ? alphabeticalTags.filter((t) =>
+        t.name.includes(filter.toLowerCase()),
+      )
+    : null
+
+  function handleOpenChange(next: boolean) {
+    onOpenChange(next)
+    if (!next) setFilter("")
+  }
+
+  function handleSelect() {
+    handleOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent
+        className="fixed bottom-0 left-0 top-auto translate-x-0 translate-y-0 w-full max-w-full rounded-t-xl rounded-b-none max-h-[70vh] flex flex-col sm:max-w-full"
+      >
+        <DialogHeader>
+          <DialogTitle className="text-base">Browse Tags</DialogTitle>
+        </DialogHeader>
+
+        {showSearch && (
+          <Input
+            placeholder="Search tags…"
+            className="h-8 text-sm"
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Escape") {
+                setFilter("")
+                ;(e.target as HTMLInputElement).blur()
+              }
+            }}
+          />
+        )}
+
+        <div className="overflow-y-auto flex-1 -mx-6 px-6">
+          {filteredTags !== null ? (
+            <FilteredTagList
+              tags={filteredTags}
+              activeTag={activeTag}
+              onSelect={handleSelect}
+            />
+          ) : (
+            <BrowseTagSections
+              popularTags={popularTags}
+              alphabeticalTags={alphabeticalTags}
+              activeTag={activeTag}
+              onSelect={handleSelect}
+            />
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function FilteredTagList({
+  tags,
+  activeTag,
+  onSelect,
+}: {
+  tags: TagWithCount[]
+  activeTag?: string
+  onSelect: () => void
+}) {
+  if (tags.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground italic py-4">
+        No matching tags.
+      </p>
+    )
+  }
+
+  return (
+    <div className="space-y-1 py-2">
+      {tags.map((tag) => (
+        <SheetTagRow
+          key={tag.id}
+          tag={tag}
+          isActive={activeTag === tag.name}
+          onClick={onSelect}
+        />
+      ))}
+    </div>
+  )
+}
+
+function BrowseTagSections({
+  popularTags,
+  alphabeticalTags,
+  activeTag,
+  onSelect,
+}: {
+  popularTags: TagWithCount[]
+  alphabeticalTags: TagWithCount[]
+  activeTag?: string
+  onSelect: () => void
+}) {
+  return (
+    <>
+      <section className="py-2">
+        <h3 className="text-xs font-medium uppercase tracking-wider text-muted-foreground/60 mb-2">
+          Popular
+        </h3>
+        <div className="space-y-1">
+          {popularTags.map((tag) => (
+            <SheetTagRow
+              key={tag.id}
+              tag={tag}
+              isActive={activeTag === tag.name}
+              showCount
+              onClick={onSelect}
+            />
+          ))}
+        </div>
+      </section>
+
+      <div className="border-t border-border my-2" />
+
+      <section className="py-2">
+        <h3 className="text-xs font-medium uppercase tracking-wider text-muted-foreground/60 mb-2">
+          All
+        </h3>
+        <div className="space-y-1">
+          {alphabeticalTags.map((tag) => (
+            <SheetTagRow
+              key={tag.id}
+              tag={tag}
+              isActive={activeTag === tag.name}
+              onClick={onSelect}
+            />
+          ))}
+        </div>
+      </section>
+    </>
+  )
+}
+
+function SheetTagRow({
+  tag,
+  isActive,
+  showCount = false,
+  onClick,
+}: {
+  tag: TagWithCount
+  isActive: boolean
+  showCount?: boolean
+  onClick: () => void
+}) {
+  return (
+    <Link
+      to="/"
+      search={(prev: StreamSearch) => ({ q: prev.q, tag: tag.name })}
+      onClick={onClick}
+      aria-current={isActive ? "page" : undefined}
+      className={cn(
+        "flex items-center justify-between py-1.5 px-2 rounded-md no-underline transition-colors text-sm",
+        isActive
+          ? "bg-foreground text-background font-medium"
+          : "text-foreground hover:bg-secondary",
+      )}
+    >
+      <span className="truncate">{tag.name}</span>
+      {showCount && (
+        <span className="text-xs text-muted-foreground ml-2 shrink-0">
+          {tag.theme_count}
+        </span>
+      )}
+    </Link>
+  )
+}

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -43,7 +43,7 @@ function ReaderStream() {
 
   return (
     <div className="flex flex-col md:flex-row gap-6 md:gap-10">
-      <div className="md:hidden">
+      <div className="md:hidden sticky top-0 z-10 bg-background pt-2 pb-1">
         <TagBar activeTag={tag} horizontal />
       </div>
 


### PR DESCRIPTION
## Summary
- Truncate mobile tag row to 12 pills with a "+N more" chip that opens a bottom sheet
- Bottom sheet shows "Popular" (top 10 by usage with counts) and "All" (alphabetical)
- Search input appears inside sheet at 40+ tags
- Active tag promotion: if selected tag is beyond visible set, swap it in
- Sticky tag row so filter stays visible while scrolling content

## Thresholds
| Tags | Mobile Behavior |
|------|----------------|
| Under 12 | No change — all pills shown |
| 12-39 | Truncated row + "+N more" → bottom sheet (Popular + All) |
| 40+ | Same + search input in bottom sheet |

Closes #44

## Test plan
- [ ] With <12 tags: no "+N more" chip, no sheet
- [ ] With 12+ tags: "+N more" chip appears, tapping opens bottom sheet
- [ ] Bottom sheet shows Popular section (top 10 with counts) and All section (alphabetical)
- [ ] Selecting a tag in sheet navigates and closes sheet
- [ ] Active tag in hidden set gets promoted to visible row
- [ ] With 40+ tags: search input appears in sheet, filters by substring
- [ ] Tag row stays sticky when scrolling content
- [ ] Sheet close button works, overlay tap closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily UI/UX changes to tag navigation on mobile with limited logic (truncation, active-tag promotion, simple filtering) and no backend/security impact; main risk is minor regressions in tag selection and filtering behavior.
> 
> **Overview**
> Improves mobile tag discovery by truncating the horizontal `TagBar` to 12 pills and adding a `+N more` control that opens a new bottom-sheet `TagSheet` for browsing the full tag list.
> 
> The sheet provides *Popular* (top 10, with counts) and *All* (alphabetical) sections, optionally shows a search box at 40+ tags, and closes on tag selection; the active tag is promoted into the visible pill row when it would otherwise be hidden. The mobile tag row on the index route is now sticky so tag filtering stays visible while scrolling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0866ecfcb05663d22af312a4dec36ad9d8b58215. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->