### PR TITLE
feat: upgrade cover images from thumbnails to accent banners

### DIFF
--- a/frontend/src/components/theme-section.tsx
+++ b/frontend/src/components/theme-section.tsx
@@ -31,21 +31,17 @@ export function ThemeSection({ theme, variant = "feed" }: ThemeSectionProps) {
 
   return (
     <article id={`theme-${theme.id}`} className="group/theme space-y-3">
-      {theme.image_url && variant === "permalink" && (
+      {theme.image_url && (
         <img
           src={theme.image_url}
           alt=""
-          className="w-60 h-60 rounded object-cover"
+          className={cn(
+            "w-full rounded-lg object-cover",
+            variant === "permalink" ? "aspect-[5/2]" : "aspect-[3/1]",
+          )}
         />
       )}
       <div className="flex items-start gap-3">
-        {theme.image_url && variant === "feed" && (
-          <img
-            src={theme.image_url}
-            alt=""
-            className="w-14 h-14 rounded object-cover flex-shrink-0 mt-0.5"
-          />
-        )}
         <div className="prose prose-sm max-w-none flex-1">
           <Markdown>{theme.body_md}</Markdown>
         </div>


### PR DESCRIPTION
## Summary
- Replace 56px circular thumbnails with full-width accent banners in the feed (3:1 aspect ratio)
- Permalink pages get a wider 5:2 banner for more breathing room
- Consolidates two separate image render paths (feed vs permalink) into one unified block above the body text

## Design Research
Based on patterns from The Marginalian, Medium, Substack, and Ghost:
- **3:1 aspect ratio** adds visual flavor without overwhelming writing (~220px tall vs 380px for 16:9)
- Full content width creates coherence with the text column
- Works well on mobile (unlike 16:9 which feels thin on small screens)
- Acts as a section divider signaling "new theme starts here" in the continuous stream

## Test plan
- [ ] Feed view: themes with images show full-width 3:1 banner above body text
- [ ] Feed view: themes without images render normally (no empty space)
- [ ] Permalink view: image displays at 5:2 aspect ratio
- [ ] Mobile: images still have visual presence, not paper-thin
- [ ] `object-cover` handles square AI-generated images gracefully (crops center)

🤖 Generated with [Claude Code](https://claude.com/claude-code)