### PR TITLE
feat: auto-populate AI tag suggestions after theme creation (#49)

### DIFF
--- a/frontend/src/components/ui/tag-input.tsx
+++ b/frontend/src/components/ui/tag-input.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useQuery } from "@tanstack/react-query"
-import { Plus, X } from "lucide-react"
+import { Plus, Sparkles, X } from "lucide-react"
 import { fetchTags } from "@/lib/api"
 import { Badge } from "@/components/ui/badge"
 import { cn } from "@/lib/utils"
@@ -12,6 +12,7 @@ interface TagInputProps {
   id?: string
   disabled?: boolean
   className?: string
+  aiSuggestedTags?: string[]
 }
 
 /** Normalize a raw tag string: trim, lowercase, whitespace to hyphens. */
@@ -39,7 +40,12 @@ export function TagInput({
   id,
   disabled,
   className,
+  aiSuggestedTags,
 }: TagInputProps) {
+  const aiSuggestedSet = useMemo(
+    () => new Set(aiSuggestedTags ?? []),
+    [aiSuggestedTags],
+  )
   const [inputValue, setInputValue] = useState("")
   const [isOpen, setIsOpen] = useState(false)
   const [highlightedIndex, setHighlightedIndex] = useState(-1)
@@ -235,6 +241,9 @@ export function TagInput({
               !existingTagNames.has(tag) && "border-dashed",
             )}
           >
+            {aiSuggestedSet.has(tag) && (
+              <Sparkles className="size-3 text-muted-foreground" aria-label="AI suggested" />
+            )}
             {tag}
             <button
               type="button"

--- a/frontend/src/components/writer/create-theme-dialog.tsx
+++ b/frontend/src/components/writer/create-theme-dialog.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react"
 import { useNavigate } from "@tanstack/react-router"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { Loader2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Textarea } from "@/components/ui/textarea"
 import { Label } from "@/components/ui/label"
@@ -13,29 +14,55 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
-import { createTheme } from "@/lib/api"
+import { createTheme, suggestTags, updateTheme } from "@/lib/api"
 
 interface CreateThemeDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
 }
 
+type Phase = "compose" | "review-tags"
+
 export function CreateThemeDialog({ open, onOpenChange }: CreateThemeDialogProps) {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const [body, setBody] = useState("")
   const [tags, setTags] = useState<string[]>([])
+  const [phase, setPhase] = useState<Phase>("compose")
+  const [createdThemeId, setCreatedThemeId] = useState<number | null>(null)
+  const [aiSuggestedTags, setAiSuggestedTags] = useState<string[]>([])
+  const [isSuggesting, setIsSuggesting] = useState(false)
 
-  const mutation = useMutation({
+  const createMutation = useMutation({
     mutationFn: createTheme,
-    onSuccess: (newTheme) => {
+    onSuccess: async (newTheme) => {
+      setCreatedThemeId(newTheme.id)
+      setIsSuggesting(true)
+      setPhase("review-tags")
+
+      try {
+        const result = await suggestTags(newTheme.id)
+        setTags(result.tags)
+        setAiSuggestedTags(result.tags)
+      } catch {
+        // Suggestion failed — let writer add tags manually
+      } finally {
+        setIsSuggesting(false)
+      }
+    },
+  })
+
+  const saveMutation = useMutation({
+    mutationFn: ({ themeId, tags }: { themeId: number; tags: string[] }) =>
+      updateTheme(themeId, { tags: tags.map((name) => ({ name })) }),
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["themes"] })
       queryClient.invalidateQueries({ queryKey: ["tags"] })
       onOpenChange(false)
       resetForm()
       navigate({
         to: "/writer/themes/$themeId",
-        params: { themeId: String(newTheme.id) },
+        params: { themeId: String(createdThemeId) },
       })
     },
   })
@@ -43,55 +70,83 @@ export function CreateThemeDialog({ open, onOpenChange }: CreateThemeDialogProps
   function resetForm() {
     setBody("")
     setTags([])
+    setPhase("compose")
+    setCreatedThemeId(null)
+    setAiSuggestedTags([])
+    setIsSuggesting(false)
   }
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
-    if (!body.trim()) return
-    mutation.mutate({
-      body_md: body.trim(),
-      tags: tags.length > 0 ? tags.map((name) => ({ name })) : undefined,
-    })
+    if (phase === "compose") {
+      if (!body.trim()) return
+      createMutation.mutate({ body_md: body.trim() })
+    } else if (phase === "review-tags" && createdThemeId !== null) {
+      saveMutation.mutate({ themeId: createdThemeId, tags })
+    }
   }
 
+  function handleOpenChange(open: boolean) {
+    if (!open) resetForm()
+    onOpenChange(open)
+  }
+
+  const isLoading = createMutation.isPending || isSuggesting || saveMutation.isPending
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent>
         <form onSubmit={handleSubmit}>
           <DialogHeader>
             <DialogTitle>New Theme</DialogTitle>
             <DialogDescription>
-              Create a new theme to organize your breadcrumbs.
+              {phase === "compose"
+                ? "Create a new theme to organize your breadcrumbs."
+                : "Review the suggested tags. Remove any that don't fit."}
             </DialogDescription>
           </DialogHeader>
 
           <div className="space-y-4 py-4">
-            <div className="space-y-2">
-              <Label htmlFor="body">Body</Label>
-              <Textarea
-                id="body"
-                value={body}
-                onChange={(e) => setBody(e.target.value)}
-                placeholder="Write your thought..."
-                rows={4}
-                required
-              />
-            </div>
+            {phase === "compose" && (
+              <div className="space-y-2">
+                <Label htmlFor="body">Body</Label>
+                <Textarea
+                  id="body"
+                  value={body}
+                  onChange={(e) => setBody(e.target.value)}
+                  placeholder="Write your thought..."
+                  rows={4}
+                  required
+                />
+              </div>
+            )}
 
-            <div className="space-y-2">
-              <Label htmlFor="tags">Tags</Label>
-              <TagInput
-                id="tags"
-                value={tags}
-                onChange={setTags}
-                placeholder="e.g. react, architecture, patterns"
-              />
-            </div>
+            {phase === "review-tags" && (
+              <div className="space-y-2">
+                <Label htmlFor="tags" className="flex items-center gap-2">
+                  Tags
+                  {isSuggesting && (
+                    <span className="flex items-center gap-1 text-xs text-muted-foreground font-normal">
+                      <Loader2 className="size-3 animate-spin" />
+                      Suggesting…
+                    </span>
+                  )}
+                </Label>
+                <TagInput
+                  id="tags"
+                  value={tags}
+                  onChange={setTags}
+                  placeholder="Add tags…"
+                  disabled={isSuggesting}
+                  aiSuggestedTags={aiSuggestedTags}
+                />
+              </div>
+            )}
           </div>
 
-          {mutation.error && (
+          {(createMutation.error || saveMutation.error) && (
             <p className="text-sm text-destructive pb-2">
-              {mutation.error.message}
+              {(createMutation.error ?? saveMutation.error)?.message}
             </p>
           )}
 
@@ -99,12 +154,21 @@ export function CreateThemeDialog({ open, onOpenChange }: CreateThemeDialogProps
             <Button
               type="button"
               variant="outline"
-              onClick={() => onOpenChange(false)}
+              onClick={() => handleOpenChange(false)}
             >
               Cancel
             </Button>
-            <Button type="submit" disabled={mutation.isPending || !body.trim()}>
-              {mutation.isPending ? "Creating..." : "Create Theme"}
+            <Button
+              type="submit"
+              disabled={isLoading || (phase === "compose" && !body.trim())}
+            >
+              {phase === "compose"
+                ? createMutation.isPending
+                  ? "Creating…"
+                  : "Create Theme"
+                : saveMutation.isPending
+                  ? "Saving…"
+                  : "Save Tags"}
             </Button>
           </DialogFooter>
         </form>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -321,6 +321,13 @@ export async function uploadImage(file: File): Promise<{ url: string }> {
   return res.json()
 }
 
+export function suggestTags(themeId: number): Promise<{ tags: string[] }> {
+  return apiMutate(`/api/themes/${themeId}/suggest-tags`, {
+    method: "POST",
+    label: "suggest tags",
+  })
+}
+
 export function subscribe(email: string): Promise<{ message: string }> {
   return apiMutate("/api/subscribers/subscribe", {
     method: "POST",


### PR DESCRIPTION
## Summary
- Two-phase create-theme dialog: Phase 1 = write body, Phase 2 = review AI-suggested tags
- After theme is created, `POST /api/themes/{id}/suggest-tags` is called automatically
- Suggested tags are pre-filled with a ✨ sparkle indicator (per-chip, via new `aiSuggestedTags` prop on `TagInput`)
- Writer can remove, add, or modify tags before saving (tags saved via PUT /api/themes/{id})
- Loading state shown while suggestions fetch; silent fallback if suggestion fails
- Clean TypeScript + full production build verified

## Test plan
- [ ] Create a new theme — dialog should advance to tag review phase after creation
- [ ] Tags pre-fill with sparkle icons; loading spinner shows while fetching
- [ ] Suggestions can be removed by clicking ✕; new tags can be added manually
- [ ] "Save Tags" saves and navigates to the theme page
- [ ] Cancel at either phase closes the dialog cleanly (no orphaned theme)
- [ ] If backend is down/returns 503, tag input stays empty and editable (no error shown to writer)

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)