### PR TITLE
fix: clean error message for Anthropic API failures in image generation

### DIFF
--- a/app/images/providers.py
+++ b/app/images/providers.py
@@ -77,7 +77,7 @@ class ClaudeVisualizer:
             )
         except anthropic.APIError as e:
             logger.error("Claude visualizer API error: %s", e)
-            raise ImageGenerationError(f"Visualizer error: {e}") from e
+            raise ImageGenerationError(f"Visualizer error: {e.message}") from e
 
         if not response.content:
             raise ImageGenerationError("Visualizer returned empty response")


### PR DESCRIPTION
## Summary

- `str(anthropic.APIError)` dumps the full JSON response body (type, message, request_id) — this was leaking raw API internals into the UI as "Visualizer error: Error code: 400 - {'type': 'error', ...}"
- Switch to `e.message` which is just the human-readable string (e.g. "Your credit balance is too low to access the Anthropic API.")

## Test plan

- [ ] Existing test `test_claude_visualizer_wraps_api_errors` still passes (confirmed locally)
- [ ] Trigger image generation with an invalid/exhausted API key — error panel should now show a clean sentence instead of raw JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)