### PR TITLE
fix: push diversity directive upstream into the visualizer

### DIFF
--- a/app/images/providers.py
+++ b/app/images/providers.py
@@ -39,7 +39,12 @@ Rules:
 - Describe what an observer would SEE. Start with a concrete noun phrase.
 - Translate abstract concepts into visual metaphors. "Autonomy" might become \
 "a single machine alone in a quiet glass room"; "attention" might become \
-"a figure leaning forward over a steaming cup."
+"a middle-aged Filipina nurse leaning forward over a steaming cup."
+- When the scene includes a person, name them with specific demographic detail — \
+ethnicity, age, gender, build, distinguishing features — chosen to fit the theme. \
+Don't default to one prototype (white, male, young, thin); across themes the \
+rendered range should feel like the world. Vary skin tones, ages, gender \
+presentations, and body types naturally, as the theme allows.
 - Do NOT repeat the theme's phrasing verbatim. Interpret, don't echo.
 - Do NOT use meta-language ("a painting showing X", "an image of Y"). Just the scene.
 - Do NOT include any style or medium notes — those are added downstream.

--- a/app/images/service.py
+++ b/app/images/service.py
@@ -13,7 +13,9 @@ STYLE_SUFFIX = (
     "Rendered as a flat oil painting in a limited three-color palette, "
     "figurative and confident, contemporary museum-quality painting, "
     "tone balanced between gravity and play. "
-    "If human figures are included, represent varied skin tones, ages, and body types. "
+    "Render any human figure exactly as the scene describes; do not default to a "
+    "white or male or young or thin figure when the scene calls for someone "
+    "different. "
     "When hands are visible, they rest calmly at the sides, are folded, or hold "
     "a single object — never reaching, gesturing, or pointing."
 )


### PR DESCRIPTION
## Summary

- `flux-schnell-lora` (the model we switched to in #73) has a stronger white-male-young-thin prior than the canonical pool. The style suffix's mild \"varied skin tones\" line gets ignored.
- The real lever is **Claude**, not the style suffix. Claude writes prose like \"a figure leaning forward\"; Flux fills the gap with its prior. If Claude instead writes \"a middle-aged Filipina nurse leaning forward,\" Flux renders exactly that.
- Updates `VISUALIZER_SYSTEM_PROMPT` to require concrete demographic detail (ethnicity, age, gender, build) chosen to fit the theme, with explicit guidance not to default to a single prototype.
- Tightens `STYLE_SUFFIX` to back the directive: render figures exactly as described, don't fall back to white/male/young/thin.

## Test plan

- [x] 38/38 image tests pass
- [ ] Regenerate a few themes after deploy; eyeball that the rendered range feels varied across skin tones, ages, genders, and body types without feeling tokenistic
- [ ] If a single regenerate still skews narrow on one theme, that's expected — variety should be visible across themes, not within four candidates of the same prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)