### PR TITLE
fix: retry once on Replicate ModelError; widen except to ReplicateException

### DIFF
--- a/app/images/providers.py
+++ b/app/images/providers.py
@@ -168,27 +168,39 @@ class ReplicateImageGenerator:
         return urls
 
     def _generate_one(self, prompt: str) -> str:
-        try:
-            output = self._runner(
-                self._model,
-                input={
-                    "prompt": prompt,
-                    "num_outputs": 1,
-                    "aspect_ratio": self._aspect_ratio,
-                    "output_format": "webp",
-                    "output_quality": 90,
-                },
-            )
-        except replicate.exceptions.ReplicateError as e:
-            raise ImageGenerationError(f"Replicate error: {e}") from e
-        except httpx.HTTPError as e:
-            raise ImageGenerationError(f"Network error: {e}") from e
+        # ModelError (CUDA OOM, transient prediction failures) is a sibling of
+        # ReplicateError under ReplicateException — catch the base so we don't 500
+        # on shared-GPU saturation. Retry once on ModelError: the next attempt
+        # routes to a different worker and almost always succeeds.
+        last_error: Exception | None = None
+        for attempt in range(2):
+            try:
+                output = self._runner(
+                    self._model,
+                    input={
+                        "prompt": prompt,
+                        "num_outputs": 1,
+                        "aspect_ratio": self._aspect_ratio,
+                        "output_format": "webp",
+                        "output_quality": 90,
+                    },
+                )
+            except replicate.exceptions.ModelError as e:
+                last_error = e
+                logger.warning("Replicate ModelError on attempt %d: %s", attempt + 1, e)
+                continue
+            except replicate.exceptions.ReplicateException as e:
+                raise ImageGenerationError(f"Replicate error: {e}") from e
+            except httpx.HTTPError as e:
+                raise ImageGenerationError(f"Network error: {e}") from e
 
-        items = list(output)
-        if not items:
-            raise ImageGenerationError("Replicate returned empty output")
-        item = items[0]
-        return str(item.url) if hasattr(item, "url") else str(item)
+            items = list(output)
+            if not items:
+                raise ImageGenerationError("Replicate returned empty output")
+            item = items[0]
+            return str(item.url) if hasattr(item, "url") else str(item)
+
+        raise ImageGenerationError(f"Replicate model error after retry: {last_error}") from last_error
 
 
 # ---------- R2 image store ----------

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -312,6 +312,44 @@ def test_replicate_generator_raises_when_all_calls_fail(monkeypatch):
         generator.generate("prompt")
 
 
+def _make_model_error(msg: str):
+    """ModelError takes a Prediction-like object whose .error it reports."""
+    import replicate.exceptions
+    stub = type("PredictionStub", (), {"error": msg})()
+    return replicate.exceptions.ModelError(stub)
+
+
+def test_replicate_generator_retries_once_on_model_error(monkeypatch):
+    """CUDA OOM lands on a random worker — one retry usually picks a healthy one."""
+    import replicate.exceptions
+    monkeypatch.setenv("REPLICATE_API_TOKEN", "fake")
+    calls = {"n": 0}
+
+    def oom_then_ok(model, input):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise _make_model_error("CUDA out of memory")
+        return ["https://r/ok.webp"]
+
+    generator = ReplicateImageGenerator(runner=oom_then_ok, num_outputs=1)
+    urls = generator.generate("prompt")
+    assert urls == ["https://r/ok.webp"]
+    assert calls["n"] == 2  # one failure, one retry
+
+
+def test_replicate_generator_gives_up_after_repeated_model_errors(monkeypatch):
+    """If the retry also OOMs, the candidate is a clean failure (not a 500)."""
+    import replicate.exceptions
+    monkeypatch.setenv("REPLICATE_API_TOKEN", "fake")
+    persistent_oom = MagicMock(
+        side_effect=_make_model_error("CUDA out of memory")
+    )
+    generator = ReplicateImageGenerator(runner=persistent_oom, num_outputs=1)
+    with pytest.raises(ImageGenerationError, match="model error after retry"):
+        generator.generate("prompt")
+    assert persistent_oom.call_count == 2  # initial + one retry
+
+
 def test_replicate_generator_times_out_stuck_predictions(monkeypatch):
     """A wedged Replicate prediction must not hang the request forever."""
     import time


### PR DESCRIPTION
## Summary
- CUDA OOMs on the shared flux-schnell-lora GPU were surfacing as **500s** because `ModelError` is a sibling of `ReplicateError` under `ReplicateException` — it escaped both the per-candidate except in `_generate_one` and the outer `ImageGenerationError` catch in `generate()`, aborting the whole request before sibling futures were awaited.
- `_generate_one` now catches `ModelError` separately and **retries the prediction once**; the retry lands on a different worker in the shared pool and almost always succeeds. The fallthrough except is widened from `ReplicateError` → `ReplicateException` so no future SDK exception sibling can 500 us again.
- Two new tests cover the retry-succeeds and retry-also-fails paths.

## Test plan
- [x] `uv run pytest tests/test_images.py` — 40 passed
- [ ] After merge + deploy: click Generate on the failing theme (#82) and confirm a candidate grid appears