### PR TITLE
chore: PR-only CI trigger + concurrency cancel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,17 @@
 name: CI
 
+# PR-only. Re-running the full backend+frontend matrix on the squash-merge push
+# was pure duplication. Railway auto-deploys from git push independently of
+# Actions, so deploys are unaffected. See
+# ~/.claude/knowledge-base/github-actions-cost-control.md
 on:
   pull_request:
     branches: [main]
-  push:
-    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   backend:


### PR DESCRIPTION
Cross-repo GitHub Actions cost cleanup. `ci.yml` ran on both `push: main` and `pull_request: main`, double-billing every PR — once on the PR head, again on the squash-merge commit. The required check (where present) is satisfied by the PR run; deploys are handled separately (platform-driven on Railway/Render, or via a dedicated `deploy.yml` on homebase). Also adds `concurrency: cancel-in-progress` so rapid fixup pushes don't stack parallel runs.

Full playbook: `~/.claude/knowledge-base/github-actions-cost-control.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)