### PR TITLE
Three reader-facing polish fixes: markdown digests, reduced motion, permalink icon

### DIFF
--- a/frontend/src/components/collapsed-month-card.tsx
+++ b/frontend/src/components/collapsed-month-card.tsx
@@ -101,7 +101,7 @@ export function CollapsedMonthCard({ month, digests, isOpen, onToggle }: Props) 
                 </h3>
                 <div className="space-y-8 pl-4 border-l-2 border-border">
                   {item.themes.map((theme) => (
-                    <ThemeSection key={theme.id} theme={theme} />
+                    <ThemeSection key={theme.id} theme={theme} animate={false} />
                   ))}
                 </div>
               </section>

--- a/frontend/src/components/collapsed-month-card.tsx
+++ b/frontend/src/components/collapsed-month-card.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query"
 import { ChevronDown, Sparkles } from "lucide-react"
+import Markdown from "react-markdown"
 import { ThemeSection } from "@/components/theme-section"
 import { WeeklySummary } from "@/components/weekly-summary"
 import { fetchThemes } from "@/lib/api"
@@ -66,9 +67,11 @@ export function CollapsedMonthCard({ month, digests, isOpen, onToggle }: Props) 
             </span>
           </div>
           {!isOpen && month.monthly_digest && (
-            <p className="mt-2 text-sm leading-relaxed text-muted-foreground line-clamp-3">
-              {month.monthly_digest.summary_md}
-            </p>
+            <div className="mt-2 line-clamp-3">
+              <div className="prose prose-sm max-w-none text-sm leading-relaxed text-muted-foreground">
+                <Markdown>{month.monthly_digest.summary_md}</Markdown>
+              </div>
+            </div>
           )}
         </div>
       </button>
@@ -77,9 +80,9 @@ export function CollapsedMonthCard({ month, digests, isOpen, onToggle }: Props) 
         <div className="mt-4 space-y-8">
           {month.monthly_digest && (
             <div className="relative rounded-md border border-dashed border-border/60 bg-muted/20 px-4 py-3">
-              <p className="text-sm leading-relaxed text-muted-foreground">
-                {month.monthly_digest.summary_md}
-              </p>
+              <div className="prose prose-sm max-w-none text-sm leading-relaxed text-muted-foreground">
+                <Markdown>{month.monthly_digest.summary_md}</Markdown>
+              </div>
               <span title="AI-generated summary">
                 <Sparkles className="absolute bottom-2 right-3 h-3 w-3 text-muted-foreground/25" />
               </span>

--- a/frontend/src/components/theme-section.tsx
+++ b/frontend/src/components/theme-section.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react"
 import { useQuery } from "@tanstack/react-query"
 import { Link } from "@tanstack/react-router"
+import { Link2 } from "lucide-react"
 import Markdown from "react-markdown"
 import { fetchBreadcrumbs } from "@/lib/api"
 import { useScrollReveal } from "@/hooks/use-scroll-reveal"
@@ -32,8 +33,18 @@ export function ThemeSection({ theme, variant = "feed", animate = true }: ThemeS
   const isFeed = variant === "feed"
 
   return (
-    <article id={`theme-${theme.id}`} className="space-y-3">
+    <article id={`theme-${theme.id}`} className="group space-y-3">
       <div className="relative">
+        {isFeed && (
+          <Link
+            to="/themes/$themeId"
+            params={{ themeId: String(theme.id) }}
+            aria-label="Theme permalink"
+            className="absolute top-0 right-0 z-10 p-1 opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity"
+          >
+            <Link2 className="size-3.5 text-muted-foreground/50 hover:text-foreground" />
+          </Link>
+        )}
         {theme.image_url && (
           <img
             src={theme.image_url}
@@ -48,19 +59,10 @@ export function ThemeSection({ theme, variant = "feed", animate = true }: ThemeS
           className={cn(
             "prose prose-sm max-w-none",
             theme.image_url && "mt-3",
-            isFeed && "[&_a]:relative [&_a]:z-10",
           )}
         >
           <Markdown>{theme.body_md}</Markdown>
         </div>
-        {isFeed && (
-          <Link
-            to="/themes/$themeId"
-            params={{ themeId: String(theme.id) }}
-            className="absolute inset-0 z-0 rounded-lg"
-            aria-label="View theme permalink"
-          />
-        )}
       </div>
 
       {isLoading && <BreadcrumbSkeleton />}

--- a/frontend/src/components/theme-section.tsx
+++ b/frontend/src/components/theme-section.tsx
@@ -11,9 +11,10 @@ import { cn } from "@/lib/utils"
 interface ThemeSectionProps {
   theme: ThemePublic
   variant?: "feed" | "permalink"
+  animate?: boolean
 }
 
-export function ThemeSection({ theme, variant = "feed" }: ThemeSectionProps) {
+export function ThemeSection({ theme, variant = "feed", animate = true }: ThemeSectionProps) {
   const {
     data: breadcrumbs,
     isLoading,
@@ -73,7 +74,7 @@ export function ThemeSection({ theme, variant = "feed" }: ThemeSectionProps) {
       {tree.length > 0 && (
         <div className="pl-4">
           {tree.map((node, i) => (
-            <BreadcrumbTree key={node.id} node={node} depth={0} index={i} />
+            <BreadcrumbTree key={node.id} node={node} depth={0} index={i} animate={animate} />
           ))}
         </div>
       )}
@@ -102,31 +103,34 @@ function BreadcrumbTree({
   node,
   depth,
   index,
+  animate,
 }: {
   node: BreadcrumbNode
   depth: number
   index: number
+  animate: boolean
 }) {
   const { ref, revealed } = useScrollReveal<HTMLDivElement>()
   const indent = INDENT_PX[Math.min(depth, 3)]
+  const isRevealed = !animate || revealed
 
   return (
-    <div ref={ref} style={indent > 0 ? { marginLeft: indent } : undefined}>
+    <div ref={animate ? ref : undefined} style={indent > 0 ? { marginLeft: indent } : undefined}>
       {depth === 0 && index > 0 && (
         <div className="flex justify-center py-0.5">
           <span className="text-muted-foreground/30 text-xs">·</span>
         </div>
       )}
       <div
-        className={cn("opacity-0", revealed && "animate-fade-up")}
-        style={revealed ? { animationDelay: `${index * 50}ms` } : undefined}
+        className={cn(!isRevealed && "opacity-0", animate && revealed && "animate-fade-up")}
+        style={animate && revealed ? { animationDelay: `${index * 50}ms` } : undefined}
       >
         <div className="prose prose-sm max-w-none">
           <Markdown>{node.body_md}</Markdown>
         </div>
       </div>
       {node.children.map((child, i) => (
-        <BreadcrumbTree key={child.id} node={child} depth={depth + 1} index={i} />
+        <BreadcrumbTree key={child.id} node={child} depth={depth + 1} index={i} animate={animate} />
       ))}
     </div>
   )

--- a/frontend/src/components/weekly-summary.tsx
+++ b/frontend/src/components/weekly-summary.tsx
@@ -1,5 +1,6 @@
 import type { DigestPublic } from "@/lib/types"
 import { Sparkles } from "lucide-react"
+import Markdown from "react-markdown"
 
 function formatWeekRange(start: string, end: string): string {
   const s = new Date(start + "T00:00:00")
@@ -28,9 +29,9 @@ export function WeeklySummary({ digest }: { digest: DigestPublic }) {
         {formatDigestHeading(digest)}
       </h2>
       <div className="relative rounded-lg border border-dashed border-border/60 bg-muted/20 px-5 py-4">
-        <p className="text-sm leading-relaxed text-muted-foreground">
-          {digest.summary_md}
-        </p>
+        <div className="prose prose-sm max-w-none text-sm leading-relaxed text-muted-foreground">
+          <Markdown>{digest.summary_md}</Markdown>
+        </div>
         <span title="AI-generated summary">
           <Sparkles className="absolute bottom-2 right-3 h-3 w-3 text-muted-foreground/25" />
         </span>

--- a/frontend/src/hooks/use-scroll-reveal.ts
+++ b/frontend/src/hooks/use-scroll-reveal.ts
@@ -6,9 +6,14 @@ import { useEffect, useRef, useState } from "react"
  */
 export function useScrollReveal<T extends HTMLElement = HTMLDivElement>() {
   const ref = useRef<T>(null)
-  const [revealed, setRevealed] = useState(false)
+  const prefersReducedMotion =
+    typeof window !== "undefined" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches
+  const [revealed, setRevealed] = useState(prefersReducedMotion)
 
   useEffect(() => {
+    if (prefersReducedMotion) return
+
     const el = ref.current
     if (!el) return
 
@@ -24,7 +29,7 @@ export function useScrollReveal<T extends HTMLElement = HTMLDivElement>() {
 
     observer.observe(el)
     return () => observer.disconnect()
-  }, [])
+  }, [prefersReducedMotion])
 
   return { ref, revealed }
 }

--- a/frontend/src/routes/themes.$themeId.tsx
+++ b/frontend/src/routes/themes.$themeId.tsx
@@ -60,7 +60,7 @@ function ThemePermalink() {
   return (
     <div className="max-w-2xl mx-auto space-y-6">
       <BackLink />
-      <ThemeSection theme={theme} variant="permalink" />
+      <ThemeSection theme={theme} variant="permalink" animate={false} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Render digest summaries (`summary_md`) through `react-markdown` in `weekly-summary.tsx` and `collapsed-month-card.tsx` (both the collapsed teaser and expanded digest box), instead of interpolating them into plain `<p>` tags where markdown syntax rendered literally.
- Honor `prefers-reduced-motion: reduce` in `use-scroll-reveal.ts`: content renders fully visible immediately when set. Added an `animate` prop to `ThemeSection` (default `true`), passed as `false` from the theme permalink page and from expanded archive months in `collapsed-month-card.tsx`, since re-reading old content shouldn't replay entrance animations. The main feed keeps animating.
- Replaced the invisible whole-theme overlay `Link` (and its `[&_a]:z-10` workaround classes) in `theme-section.tsx` with a small, visible `Link2` permalink icon at the top-right of the theme block. It is always visible on touch devices and appears on hover for pointer devices, with an `aria-label` for accessibility. This stops the overlay from fighting text selection.

## Test plan
- [x] `mise run check` passes (eslint + tsc + pytest), run from repo root without piping through `tail`
- [x] `routeTree.gen.ts` unchanged (no new routes)
- [x] Manual read-through of diffs for each of the three fixes