### PR TITLE
fix: update CI workflow from npm to pnpm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,20 +39,24 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.33
+
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: npm
-          cache-dependency-path: frontend/package-lock.json
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
 
       - name: Install dependencies
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Lint
-        run: npx eslint .
+        run: pnpm exec eslint .
 
       - name: Type check
-        run: npx tsc --noEmit
+        run: pnpm exec tsc --noEmit
 
       - name: Build
-        run: npm run build
+        run: pnpm build


### PR DESCRIPTION
## Summary
- The frontend CI job ran `npm ci` and cached `frontend/package-lock.json`, but the frontend migrated to pnpm in 2f7ffb1 and that lockfile no longer exists.
- CI has been silently broken since that merge: PR-only triggers mean main never re-runs the workflow, and no PR touched the frontend job until PR #77 exposed it (setup-node failed with "Some specified paths were not resolved, unable to cache dependencies").
- Switch install, lint, type check, and build steps to pnpm, matching local dev and the Railway buildCommand.

## Test plan
- [x] Ran the equivalent steps locally: `pnpm exec eslint .`, `pnpm exec tsc --noEmit`, `pnpm build` all pass
- [x] `mise run check` passes from repo root