### PR TITLE
feat: rebind breadcrumb save to Cmd/Ctrl+Enter (#79)

### DIFF
--- a/frontend/src/components/writer/add-breadcrumb-form.tsx
+++ b/frontend/src/components/writer/add-breadcrumb-form.tsx
@@ -79,7 +79,8 @@ export function AddBreadcrumbForm({ themeId, parentId, onCancel }: AddBreadcrumb
   }
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
-    if (e.key === "Enter" && !e.shiftKey) {
+    // Cmd+Enter (macOS) / Ctrl+Enter saves; plain Enter inserts a newline.
+    if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
       e.preventDefault()
       submit()
     }
@@ -143,7 +144,7 @@ export function AddBreadcrumbForm({ themeId, parentId, onCancel }: AddBreadcrumb
       </div>
       {!parentId && (
         <p className="text-xs text-muted-foreground">
-          Enter to save &middot; Shift+Enter for new line
+          {navigator.platform.startsWith("Mac") ? "⌘" : "Ctrl"}+Enter to save
         </p>
       )}
     </form>

--- a/frontend/src/components/writer/breadcrumb-item.tsx
+++ b/frontend/src/components/writer/breadcrumb-item.tsx
@@ -81,10 +81,12 @@ export function BreadcrumbItem({ node, themeId, depth = 0 }: BreadcrumbItemProps
           value={bodyMd}
           onChange={(e) => setBodyMd(e.target.value)}
           onKeyDown={(e) => {
-            if (e.key === "Enter" && !e.shiftKey) {
+            // Cmd/Ctrl+Enter saves; plain Enter inserts a newline.
+            if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
               e.preventDefault()
               if (bodyMd.trim()) handleSave()
             }
+            if (e.key === "Escape") handleCancel()
           }}
           rows={4}
           autoFocus


### PR DESCRIPTION
## What
Adopts the markdown-input standard (GitHub, Linear) for breadcrumb authoring:
- **Enter** inserts a newline (default textarea behavior)
- **Cmd+Enter** (macOS) / **Ctrl+Enter** saves
- **Escape** cancels reply and edit modes (edit mode previously had no Escape binding)
- Hint text now reads the platform-appropriate save shortcut

## Why
Plain-Enter-to-save conflicted with the advertised markdown support: writing a list or multiple paragraphs required Shift+Enter on every line, and one reflexive Enter mid-thought published a fragment.

## Files
- `frontend/src/components/writer/add-breadcrumb-form.tsx`
- `frontend/src/components/writer/breadcrumb-item.tsx` (edit mode)

## Acceptance criteria
- [x] Enter inserts a newline in both add and edit textareas; nothing submitted
- [x] Cmd/Ctrl+Enter submits (add) or saves (edit) when body is non-empty
- [x] Escape cancels reply and edit modes
- [x] Hint text reflects the new binding
- [x] Frontend checks pass (`mise run check:web` → exit 0)

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)