### PR TITLE
feat: highlight newly added breadcrumb card on save (#80)

### DIFF
--- a/frontend/src/components/writer/add-breadcrumb-form.tsx
+++ b/frontend/src/components/writer/add-breadcrumb-form.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useRef, useState } from "react"
+import { useRef, useState } from "react"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
-import { Check, ImagePlus, Plus, X } from "lucide-react"
+import { ImagePlus, Plus, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Textarea } from "@/components/ui/textarea"
 import { createBreadcrumb, uploadImage } from "@/lib/api"
+import { useHighlight } from "./highlight-context"
 
 interface AddBreadcrumbFormProps {
   themeId: number
@@ -13,31 +14,23 @@ interface AddBreadcrumbFormProps {
 
 export function AddBreadcrumbForm({ themeId, parentId, onCancel }: AddBreadcrumbFormProps) {
   const queryClient = useQueryClient()
+  const { highlight } = useHighlight()
   const [bodyMd, setBodyMd] = useState("")
-  const [showSaved, setShowSaved] = useState(false)
   const [uploading, setUploading] = useState(false)
-  const savedTimer = useRef<ReturnType<typeof setTimeout>>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
-
-  // Clean up timer on unmount
-  useEffect(() => {
-    return () => {
-      if (savedTimer.current) clearTimeout(savedTimer.current)
-    }
-  }, [])
 
   const mutation = useMutation({
     mutationFn: (data: { body_md: string; parent_id?: number }) =>
       createBreadcrumb(themeId, data),
-    onSuccess: () => {
+    onSuccess: (created) => {
       queryClient.invalidateQueries({
         queryKey: ["themes", themeId, "breadcrumbs"],
       })
+      // The freshly added card highlights itself in the list — that entry
+      // animation is the primary "saved" signal (see #80).
+      highlight(created.id)
       setBodyMd("")
-      setShowSaved(true)
-      if (savedTimer.current) clearTimeout(savedTimer.current)
-      savedTimer.current = setTimeout(() => setShowSaved(false), 2000)
       if (parentId) {
         onCancel?.()
       } else {
@@ -134,12 +127,6 @@ export function AddBreadcrumbForm({ themeId, parentId, onCancel }: AddBreadcrumb
             <X className="size-4" />
             Cancel
           </Button>
-        )}
-        {showSaved && (
-          <span className="text-sm text-muted-foreground flex items-center gap-1 animate-in fade-in">
-            <Check className="size-3.5" />
-            Saved
-          </span>
         )}
       </div>
       {!parentId && (

--- a/frontend/src/components/writer/breadcrumb-item.tsx
+++ b/frontend/src/components/writer/breadcrumb-item.tsx
@@ -17,8 +17,9 @@ import {
 } from "@/components/ui/alert-dialog"
 import { updateBreadcrumb, deleteBreadcrumb } from "@/lib/api"
 import { AddBreadcrumbForm } from "./add-breadcrumb-form"
+import { useHighlight } from "./highlight-context"
 import type { BreadcrumbNode } from "@/lib/tree"
-import { formatDate } from "@/lib/utils"
+import { cn, formatDate } from "@/lib/utils"
 
 const INDENT_PX = [0, 16, 32, 48] as const
 
@@ -30,9 +31,11 @@ interface BreadcrumbItemProps {
 
 export function BreadcrumbItem({ node, themeId, depth = 0 }: BreadcrumbItemProps) {
   const queryClient = useQueryClient()
+  const { highlightedId } = useHighlight()
   const [editing, setEditing] = useState(false)
   const [replying, setReplying] = useState(false)
   const [bodyMd, setBodyMd] = useState(node.body_md)
+  const isHighlighted = highlightedId === node.id
 
   // Sync local state when prop changes (e.g. after mutation + refetch)
   useEffect(() => {
@@ -116,7 +119,13 @@ export function BreadcrumbItem({ node, themeId, depth = 0 }: BreadcrumbItemProps
 
   return (
     <>
-      <div className="group rounded-lg border p-3 space-y-1" style={indent > 0 ? { marginLeft: indent } : undefined}>
+      <div
+        className={cn(
+          "group rounded-lg border p-3 space-y-1 transition-colors duration-1000",
+          isHighlighted && "border-primary/40 bg-primary/10 duration-0",
+        )}
+        style={indent > 0 ? { marginLeft: indent } : undefined}
+      >
         <div className="flex items-start justify-between gap-2">
           <div className="prose prose-sm max-w-none flex-1">
             <Markdown>{node.body_md}</Markdown>

--- a/frontend/src/components/writer/highlight-context.tsx
+++ b/frontend/src/components/writer/highlight-context.tsx
@@ -1,0 +1,49 @@
+import { createContext, useCallback, useContext, useEffect, useRef, useState } from "react"
+
+interface HighlightContextValue {
+  /** The breadcrumb id to visually highlight, or null. */
+  highlightedId: number | null
+  /** Mark a breadcrumb as just-added so its card highlights briefly. */
+  highlight: (id: number) => void
+}
+
+const HighlightContext = createContext<HighlightContextValue>({
+  highlightedId: null,
+  highlight: () => {},
+})
+
+const HIGHLIGHT_MS = 2000
+
+/**
+ * Tracks the most recently created breadcrumb so its card can flash on entry.
+ * Lives at the theme-editor level so both top-level adds and nested replies
+ * (whose forms sit deep in the BreadcrumbItem recursion) can signal without
+ * prop-drilling through the tree.
+ */
+export function HighlightProvider({ children }: { children: React.ReactNode }) {
+  const [highlightedId, setHighlightedId] = useState<number | null>(null)
+  const timer = useRef<ReturnType<typeof setTimeout>>(null)
+
+  const highlight = useCallback((id: number) => {
+    setHighlightedId(id)
+    if (timer.current) clearTimeout(timer.current)
+    timer.current = setTimeout(() => setHighlightedId(null), HIGHLIGHT_MS)
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      if (timer.current) clearTimeout(timer.current)
+    }
+  }, [])
+
+  return (
+    <HighlightContext value={{ highlightedId, highlight }}>
+      {children}
+    </HighlightContext>
+  )
+}
+
+// eslint-disable-next-line react-refresh/only-export-components -- hook colocated with its provider
+export function useHighlight() {
+  return useContext(HighlightContext)
+}

--- a/frontend/src/routes/writer/themes.$themeId.tsx
+++ b/frontend/src/routes/writer/themes.$themeId.tsx
@@ -7,6 +7,7 @@ import { ThemeHeaderEditor } from "@/components/writer/theme-header-editor"
 import { ThemeImagePicker } from "@/components/writer/theme-image-picker"
 import { BreadcrumbItem } from "@/components/writer/breadcrumb-item"
 import { AddBreadcrumbForm } from "@/components/writer/add-breadcrumb-form"
+import { HighlightProvider } from "@/components/writer/highlight-context"
 import { Separator } from "@/components/ui/separator"
 
 export const Route = createFileRoute("/writer/themes/$themeId")({
@@ -86,6 +87,7 @@ function ThemeEditor() {
 
       <Separator />
 
+      <HighlightProvider>
       <div className="space-y-4">
         <h3 className="text-base font-semibold">
           Breadcrumbs
@@ -122,6 +124,7 @@ function ThemeEditor() {
 
         <AddBreadcrumbForm themeId={id} />
       </div>
+      </HighlightProvider>
     </div>
   )
 }


### PR DESCRIPTION
## What
On successful create, the freshly added breadcrumb card briefly highlights (border + background tint) as it appears in the list, then fades out over ~1s. Replaces the disembodied "Saved" check next to the buttons.

## Why
The old flow cleared the textarea and flashed a "Saved" check with no visual continuity between what was typed and where it landed — the writer couldn't tell whether they'd just saved or were starting fresh. The card highlight makes the save event legible by drawing the eye to the new content.

## How
- New `HighlightProvider` context at the theme-editor level tracks the most recently created breadcrumb id. Both the top-level add form and nested reply forms (which live deep in the `BreadcrumbItem` recursion) call `highlight(id)` on success without prop-drilling.
- `BreadcrumbItem` applies an instant tint when it matches, and a `transition-colors duration-1000` fades it back when the id clears after 2s.
- Dropped the `showSaved` state and its "Saved" span; the highlight is now the primary signal.

## Acceptance criteria
- [x] Saving a top-level breadcrumb highlights the new card as it appears
- [x] Saving a reply highlights the new reply card (same context path)
- [x] Highlight self-dismisses after ~2s; no lingering state
- [x] No layout shift beyond the new card appearing (tint only, no size change)
- [x] Frontend checks pass (`mise run check:web` → exit 0)

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)