### PR TITLE
feat: persist in-progress drafts to localStorage (#83)

### DIFF
--- a/frontend/src/components/writer/add-breadcrumb-form.tsx
+++ b/frontend/src/components/writer/add-breadcrumb-form.tsx
@@ -4,6 +4,7 @@ import { ImagePlus, Plus, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Textarea } from "@/components/ui/textarea"
 import { createBreadcrumb, uploadImage } from "@/lib/api"
+import { useDraft } from "@/hooks/use-draft"
 import { useHighlight } from "./highlight-context"
 
 interface AddBreadcrumbFormProps {
@@ -15,7 +16,11 @@ interface AddBreadcrumbFormProps {
 export function AddBreadcrumbForm({ themeId, parentId, onCancel }: AddBreadcrumbFormProps) {
   const queryClient = useQueryClient()
   const { highlight } = useHighlight()
-  const [bodyMd, setBodyMd] = useState("")
+  // Persist top-level drafts per theme; replies are transient and don't own one.
+  const [bodyMd, setBodyMd, clearDraft] = useDraft(
+    `draft:breadcrumb:${themeId}`,
+    { enabled: !parentId },
+  )
   const [uploading, setUploading] = useState(false)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
@@ -30,7 +35,7 @@ export function AddBreadcrumbForm({ themeId, parentId, onCancel }: AddBreadcrumb
       // The freshly added card highlights itself in the list — that entry
       // animation is the primary "saved" signal (see #80).
       highlight(created.id)
-      setBodyMd("")
+      clearDraft()
       if (parentId) {
         onCancel?.()
       } else {

--- a/frontend/src/components/writer/create-theme-dialog.tsx
+++ b/frontend/src/components/writer/create-theme-dialog.tsx
@@ -15,6 +15,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog"
 import { createTheme, suggestTags, updateTheme } from "@/lib/api"
+import { useDraft } from "@/hooks/use-draft"
 
 interface CreateThemeDialogProps {
   open: boolean
@@ -26,7 +27,7 @@ type Phase = "compose" | "review-tags"
 export function CreateThemeDialog({ open, onOpenChange }: CreateThemeDialogProps) {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
-  const [body, setBody] = useState("")
+  const [body, setBody, clearBodyDraft] = useDraft("draft:new-theme")
   const [tags, setTags] = useState<string[]>([])
   const [phase, setPhase] = useState<Phase>("compose")
   const [createdThemeId, setCreatedThemeId] = useState<number | null>(null)
@@ -36,6 +37,9 @@ export function CreateThemeDialog({ open, onOpenChange }: CreateThemeDialogProps
   const createMutation = useMutation({
     mutationFn: createTheme,
     onSuccess: async (newTheme) => {
+      // The composed body is now a persisted theme, so the draft has served
+      // its purpose — clear it (and the field) before moving on.
+      clearBodyDraft()
       setCreatedThemeId(newTheme.id)
       setIsSuggesting(true)
       setPhase("review-tags")
@@ -68,7 +72,8 @@ export function CreateThemeDialog({ open, onOpenChange }: CreateThemeDialogProps
   })
 
   function resetForm() {
-    setBody("")
+    // Body is left to the draft hook: cancelling during compose keeps the
+    // writing (restored on reopen); creating the theme clears it explicitly.
     setTags([])
     setPhase("compose")
     setCreatedThemeId(null)

--- a/frontend/src/hooks/use-draft.ts
+++ b/frontend/src/hooks/use-draft.ts
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+
+const DEBOUNCE_MS = 300
+
+function readDraft(key: string, enabled: boolean): string {
+  if (!enabled) return ""
+  try {
+    return localStorage.getItem(key) ?? ""
+  } catch {
+    // localStorage unavailable (private mode / disabled) — drafts are best-effort.
+    return ""
+  }
+}
+
+/**
+ * A string value mirrored to localStorage so in-progress writing survives a
+ * stray navigation, dialog dismiss, or tab discard.
+ *
+ * Restores on mount (so remount the consumer via a `key` prop when the storage
+ * key changes), persists on change behind a short debounce, and clears the
+ * stored value when emptied or when `clear()` is called after a successful save.
+ * Pass `enabled: false` to make it behave like plain `useState` (e.g. for reply
+ * forms that shouldn't own a draft).
+ */
+export function useDraft(
+  key: string,
+  { enabled = true }: { enabled?: boolean } = {},
+): [string, (value: string) => void, () => void] {
+  const [value, setValue] = useState(() => readDraft(key, enabled))
+  const timer = useRef<ReturnType<typeof setTimeout>>(null)
+
+  useEffect(() => {
+    if (!enabled) return
+    if (timer.current) clearTimeout(timer.current)
+    timer.current = setTimeout(() => {
+      try {
+        if (value) localStorage.setItem(key, value)
+        else localStorage.removeItem(key)
+      } catch {
+        // best-effort persistence; ignore quota/availability errors
+      }
+    }, DEBOUNCE_MS)
+    return () => {
+      if (timer.current) clearTimeout(timer.current)
+    }
+  }, [key, value, enabled])
+
+  const clear = useCallback(() => {
+    setValue("")
+    if (!enabled) return
+    try {
+      localStorage.removeItem(key)
+    } catch {
+      // best-effort
+    }
+  }, [key, enabled])
+
+  return [value, setValue, clear]
+}

--- a/frontend/src/routes/writer/themes.$themeId.tsx
+++ b/frontend/src/routes/writer/themes.$themeId.tsx
@@ -122,7 +122,7 @@ function ThemeEditor() {
 
         <Separator />
 
-        <AddBreadcrumbForm themeId={id} />
+        <AddBreadcrumbForm key={id} themeId={id} />
       </div>
       </HighlightProvider>
     </div>


### PR DESCRIPTION
## What
Both authoring inputs now survive a stray navigation, dialog dismiss, or mobile tab discard by mirroring their text to localStorage.

## Why
For a capture tool, a box that can silently eat half-formed thoughts is the most trust-damaging gap there is. Previously both the new-theme dialog and the breadcrumb textarea held text only in React state.

## How
- **`useDraft` hook** (`hooks/use-draft.ts`): debounced persist on change, restore-on-mount, `clear()` on successful save, best-effort (swallows private-mode/quota errors). `enabled: false` makes it behave like plain `useState`.
- **Breadcrumb add form**: keyed `draft:breadcrumb:{themeId}` so drafts are scoped per theme. The top-level form is remounted per theme (`key={id}`) so restore-on-mount is correct across theme navigation. Reply forms stay transient (`enabled: false`).
- **New-theme dialog**: single `draft:new-theme` key. Cancelling during compose keeps the writing (restored on reopen); creating the theme clears it (the body is now a persisted theme).

## Acceptance criteria
- [x] Typing in the breadcrumb form, navigating away, returning restores the draft
- [x] Closing and reopening the new-theme dialog restores the body text
- [x] Successful save clears the stored draft; form starts empty next time
- [x] Drafts scoped per theme so two themes don't share breadcrumb drafts
- [x] Frontend checks pass (`mise run check:web` → exit 0)

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)