### PR TITLE
fix: don't strand a created theme when cancelling during tag review (#84)

### DIFF
--- a/frontend/src/components/writer/create-theme-dialog.tsx
+++ b/frontend/src/components/writer/create-theme-dialog.tsx
@@ -59,17 +59,22 @@ export function CreateThemeDialog({ open, onOpenChange }: CreateThemeDialogProps
   const saveMutation = useMutation({
     mutationFn: ({ themeId, tags }: { themeId: number; tags: string[] }) =>
       updateTheme(themeId, { tags: tags.map((name) => ({ name })) }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["themes"] })
-      queryClient.invalidateQueries({ queryKey: ["tags"] })
-      onOpenChange(false)
-      resetForm()
-      navigate({
-        to: "/writer/themes/$themeId",
-        params: { themeId: String(createdThemeId) },
-      })
-    },
+    onSuccess: (_data, variables) => goToTheme(variables.themeId),
   })
+
+  // Close the dialog and land in the new theme's editor. Every review-tags exit
+  // routes through here — saving tags, skipping them, or dismissing the dialog —
+  // so a created-but-untagged theme is never silently stranded.
+  function goToTheme(themeId: number) {
+    queryClient.invalidateQueries({ queryKey: ["themes"] })
+    queryClient.invalidateQueries({ queryKey: ["tags"] })
+    onOpenChange(false)
+    resetForm()
+    navigate({
+      to: "/writer/themes/$themeId",
+      params: { themeId: String(themeId) },
+    })
+  }
 
   function resetForm() {
     // Body is left to the draft hook: cancelling during compose keeps the
@@ -92,8 +97,18 @@ export function CreateThemeDialog({ open, onOpenChange }: CreateThemeDialogProps
   }
 
   function handleOpenChange(open: boolean) {
-    if (!open) resetForm()
-    onOpenChange(open)
+    if (open) {
+      onOpenChange(true)
+      return
+    }
+    // Dismissing (escape / overlay / Cancel) after the theme exists must
+    // acknowledge it — navigate to its editor instead of silently closing.
+    if (phase === "review-tags" && createdThemeId !== null) {
+      goToTheme(createdThemeId)
+      return
+    }
+    resetForm()
+    onOpenChange(false)
   }
 
   const isLoading = createMutation.isPending || isSuggesting || saveMutation.isPending
@@ -161,7 +176,7 @@ export function CreateThemeDialog({ open, onOpenChange }: CreateThemeDialogProps
               variant="outline"
               onClick={() => handleOpenChange(false)}
             >
-              Cancel
+              {phase === "compose" ? "Cancel" : "Skip tags"}
             </Button>
             <Button
               type="submit"


### PR DESCRIPTION
## What
Makes the new-theme dialog's state honest. The theme is created at the end of the compose phase; cancelling during the following review-tags phase used to silently leave an untagged draft the writer believed they'd backed out of. Now every review-tags exit acknowledges the theme exists and lands the writer in its editor.

## How
- **`goToTheme()` helper**: invalidates the themes/tags caches, closes, resets, and navigates to the new theme's editor. Save-tags, Skip-tags, and dialog dismiss all route through it.
- The review-tags secondary action reads **"Skip tags"** (was "Cancel") and navigates to the editor; **escape / overlay dismiss** does the same via a phase-aware `handleOpenChange`.
- **Compose-phase cancel** still simply closes with nothing created.

Rejected alternative: deleting the theme on cancel — that turns a dismissal into silent data destruction.

## Acceptance criteria
- [x] During review-tags the secondary action reads "Skip tags" and navigates to the created theme's editor
- [x] Dismissing the dialog (escape / overlay) during review-tags also navigates to the theme
- [x] Compose-phase cancel still simply closes with nothing created
- [x] Query caches invalidated so the dashboard shows the new theme either way
- [x] Frontend checks pass (`mise run check:web` → exit 0)

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)