### PR TITLE
feat: write/preview toggle on authoring textareas (#86)

### DIFF
--- a/frontend/src/components/writer/add-breadcrumb-form.tsx
+++ b/frontend/src/components/writer/add-breadcrumb-form.tsx
@@ -4,8 +4,14 @@ import { ImagePlus, Plus, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Textarea } from "@/components/ui/textarea"
 import { createBreadcrumb, uploadImage } from "@/lib/api"
+import { cn } from "@/lib/utils"
 import { useDraft } from "@/hooks/use-draft"
 import { useHighlight } from "./highlight-context"
+import {
+  MarkdownPreview,
+  WritePreviewToggle,
+  type WritePreviewMode,
+} from "./markdown-field"
 
 interface AddBreadcrumbFormProps {
   themeId: number
@@ -22,6 +28,7 @@ export function AddBreadcrumbForm({ themeId, parentId, onCancel }: AddBreadcrumb
     { enabled: !parentId },
   )
   const [uploading, setUploading] = useState(false)
+  const [mode, setMode] = useState<WritePreviewMode>("write")
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
 
@@ -96,6 +103,11 @@ export function AddBreadcrumbForm({ themeId, parentId, onCancel }: AddBreadcrumb
         className="hidden"
         onChange={handleFileSelect}
       />
+      <div className="flex justify-end">
+        <WritePreviewToggle mode={mode} onChange={setMode} />
+      </div>
+      {/* Textarea stays mounted (just hidden) in preview so content, cursor,
+          and the Cmd+Enter binding survive the toggle. */}
       <Textarea
         ref={textareaRef}
         value={bodyMd}
@@ -104,7 +116,13 @@ export function AddBreadcrumbForm({ themeId, parentId, onCancel }: AddBreadcrumb
         placeholder={parentId ? "Reply..." : "Add a breadcrumb... (supports markdown)"}
         rows={parentId ? 2 : 3}
         autoFocus={!!parentId}
+        className={cn(mode === "preview" && "hidden")}
       />
+      {mode === "preview" && (
+        <div className="rounded-md border p-3">
+          <MarkdownPreview body={bodyMd} />
+        </div>
+      )}
       {mutation.error && (
         <p className="text-sm text-destructive">{mutation.error.message}</p>
       )}

--- a/frontend/src/components/writer/breadcrumb-item.tsx
+++ b/frontend/src/components/writer/breadcrumb-item.tsx
@@ -5,6 +5,11 @@ import Markdown from "react-markdown"
 import { Button } from "@/components/ui/button"
 import { Textarea } from "@/components/ui/textarea"
 import {
+  MarkdownPreview,
+  WritePreviewToggle,
+  type WritePreviewMode,
+} from "./markdown-field"
+import {
   AlertDialog,
   AlertDialogAction,
   AlertDialogCancel,
@@ -33,6 +38,7 @@ export function BreadcrumbItem({ node, themeId, depth = 0 }: BreadcrumbItemProps
   const queryClient = useQueryClient()
   const { highlightedId } = useHighlight()
   const [editing, setEditing] = useState(false)
+  const [editMode, setEditMode] = useState<WritePreviewMode>("write")
   const [replying, setReplying] = useState(false)
   const [bodyMd, setBodyMd] = useState(node.body_md)
   const isHighlighted = highlightedId === node.id
@@ -72,6 +78,12 @@ export function BreadcrumbItem({ node, themeId, depth = 0 }: BreadcrumbItemProps
   function handleCancel() {
     setBodyMd(node.body_md)
     setEditing(false)
+    setEditMode("write")
+  }
+
+  function startEditing() {
+    setEditMode("write")
+    setEditing(true)
   }
 
   const indent = INDENT_PX[Math.min(depth, 3)]
@@ -80,6 +92,9 @@ export function BreadcrumbItem({ node, themeId, depth = 0 }: BreadcrumbItemProps
   if (editing) {
     return (
       <div className="rounded-lg border p-3 space-y-3" style={indent > 0 ? { marginLeft: indent } : undefined}>
+        <div className="flex justify-end">
+          <WritePreviewToggle mode={editMode} onChange={setEditMode} />
+        </div>
         <Textarea
           value={bodyMd}
           onChange={(e) => setBodyMd(e.target.value)}
@@ -93,7 +108,9 @@ export function BreadcrumbItem({ node, themeId, depth = 0 }: BreadcrumbItemProps
           }}
           rows={4}
           autoFocus
+          className={cn(editMode === "preview" && "hidden")}
         />
+        {editMode === "preview" && <MarkdownPreview body={bodyMd} />}
         {editMutation.error && (
           <p className="text-sm text-destructive">
             {editMutation.error.message}
@@ -142,7 +159,7 @@ export function BreadcrumbItem({ node, themeId, depth = 0 }: BreadcrumbItemProps
             <Button
               size="icon-xs"
               variant="ghost"
-              onClick={() => setEditing(true)}
+              onClick={startEditing}
             >
               <Pencil className="size-3.5" />
             </Button>

--- a/frontend/src/components/writer/markdown-field.tsx
+++ b/frontend/src/components/writer/markdown-field.tsx
@@ -1,0 +1,61 @@
+import Markdown from "react-markdown"
+import { cn } from "@/lib/utils"
+
+export type WritePreviewMode = "write" | "preview"
+
+/**
+ * Small segmented control that flips an authoring textarea between raw-markdown
+ * editing and a rendered preview. Buttons are type="button" so they never
+ * submit the surrounding form.
+ */
+export function WritePreviewToggle({
+  mode,
+  onChange,
+}: {
+  mode: WritePreviewMode
+  onChange: (mode: WritePreviewMode) => void
+}) {
+  return (
+    <div className="inline-flex rounded-md border p-0.5 text-xs">
+      {(["write", "preview"] as const).map((m) => (
+        <button
+          key={m}
+          type="button"
+          onClick={() => onChange(m)}
+          className={cn(
+            "rounded px-2 py-0.5 capitalize transition-colors",
+            mode === m
+              ? "bg-muted font-medium text-foreground"
+              : "text-muted-foreground hover:text-foreground",
+          )}
+          aria-pressed={mode === m}
+        >
+          {m}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+/**
+ * Renders markdown with the same prose styling as the read view so a preview
+ * matches what will actually be saved. Empty bodies show a muted placeholder.
+ */
+export function MarkdownPreview({
+  body,
+  className,
+}: {
+  body: string
+  className?: string
+}) {
+  if (!body.trim()) {
+    return (
+      <p className="text-sm text-muted-foreground italic">Nothing to preview</p>
+    )
+  }
+  return (
+    <div className={cn("prose prose-sm max-w-none", className)}>
+      <Markdown>{body}</Markdown>
+    </div>
+  )
+}

--- a/frontend/src/components/writer/theme-header-editor.tsx
+++ b/frontend/src/components/writer/theme-header-editor.tsx
@@ -21,6 +21,12 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog"
 import { updateTheme, deleteTheme } from "@/lib/api"
+import { cn } from "@/lib/utils"
+import {
+  MarkdownPreview,
+  WritePreviewToggle,
+  type WritePreviewMode,
+} from "./markdown-field"
 import type { ThemePublic } from "@/lib/types"
 
 interface ThemeHeaderEditorProps {
@@ -32,6 +38,7 @@ export function ThemeHeaderEditor({ theme }: ThemeHeaderEditorProps) {
   const queryClient = useQueryClient()
 
   const [editing, setEditing] = useState(false)
+  const [bodyMode, setBodyMode] = useState<WritePreviewMode>("write")
   const [body, setBody] = useState(theme.body_md)
   const [tags, setTags] = useState<string[]>(theme.tags.map((t) => t.name))
 
@@ -51,6 +58,7 @@ export function ThemeHeaderEditor({ theme }: ThemeHeaderEditorProps) {
       queryClient.invalidateQueries({ queryKey: ["themes"] })
       queryClient.invalidateQueries({ queryKey: ["tags"] })
       setEditing(false)
+      setBodyMode("write")
     },
   })
 
@@ -84,19 +92,34 @@ export function ThemeHeaderEditor({ theme }: ThemeHeaderEditorProps) {
     setBody(theme.body_md)
     setTags(theme.tags.map((t) => t.name))
     setEditing(false)
+    setBodyMode("write")
+  }
+
+  function startEditing() {
+    setBodyMode("write")
+    setEditing(true)
   }
 
   if (editing) {
     return (
       <div className="space-y-4 rounded-lg border p-4">
         <div className="space-y-2">
-          <Label htmlFor="edit-body">Body</Label>
+          <div className="flex items-center justify-between">
+            <Label htmlFor="edit-body">Body</Label>
+            <WritePreviewToggle mode={bodyMode} onChange={setBodyMode} />
+          </div>
           <Textarea
             id="edit-body"
             value={body}
             onChange={(e) => setBody(e.target.value)}
             rows={5}
+            className={cn(bodyMode === "preview" && "hidden")}
           />
+          {bodyMode === "preview" && (
+            <div className="rounded-md border p-3">
+              <MarkdownPreview body={body} />
+            </div>
+          )}
         </div>
         <div className="space-y-2">
           <Label htmlFor="edit-tags">Tags</Label>
@@ -137,7 +160,7 @@ export function ThemeHeaderEditor({ theme }: ThemeHeaderEditorProps) {
         <div className="prose prose-sm max-w-none">
           <Markdown>{theme.body_md}</Markdown>
         </div>
-        <Button size="sm" variant="outline" onClick={() => setEditing(true)}>
+        <Button size="sm" variant="outline" onClick={startEditing}>
           <Pencil className="size-4" />
           Edit
         </Button>


### PR DESCRIPTION
## What
A lightweight Write / Preview segmented control above the three authoring textareas: the breadcrumb add form, the breadcrumb edit textarea, and the theme body editor. Authors can see rendered markdown before saving instead of the type-save-see-it-wrong-fix loop.

## How
- **`markdown-field.tsx`** exports two reusable pieces:
  - `WritePreviewToggle` — a small `type="button"` segmented control (never submits the form).
  - `MarkdownPreview` — renders with the same `prose prose-sm max-w-none` styling as the read view, so preview matches the saved result; an empty body shows a muted "Nothing to preview".
- The textarea stays **mounted** (hidden via CSS `hidden`) in preview mode, so text content, cursor position, and the Cmd+Enter save binding survive the toggle.
- Mode resets to Write whenever an edit session starts or ends.

The create-dialog compose field was left out (the issue marks it optional).

## Acceptance criteria
- [x] Toggle shows rendered markdown identical in styling to the saved view
- [x] Switching back to Write preserves the text exactly (textarea never unmounts)
- [x] Empty body shows a muted "Nothing to preview" state
- [x] Frontend checks pass (`mise run check:web` → exit 0)

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)