### PR TITLE
fix: bound Replicate predictions and fail over between Flux pools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,6 +174,34 @@ See `docs/log/README.md` for format and dimensions.
 - Docker builds run `tsc` before `vite build`, so the route tree must be pre-committed
 - If you add a new route file, run `pnpm build` (or `mise run build`) locally and commit the updated `routeTree.gen.ts`
 
+**Replicate theme image generation — two distinct 503 failure modes (`app/images/providers.py`):**
+- Low account credit (<$5) triggers Replicate's own throttle; error text mentions the $5 threshold. Fix: top up billing at replicate.com, not a code change.
+- Timeouts/network errors ("All N candidates failed: timed out...; Network error: The read operation timed out") are a *different* failure — check the Replicate dashboard balance first before assuming it's the credit issue.
+
+**NEVER use `replicate.run()` here — it cannot be bounded from outside (`app/images/providers.py`):**
+- `replicate.run()` defaults to `wait=True`, which sets the httpx read timeout to **60.5s** (`replicate/prediction.py::_create_prediction_timeout`). Any wall-clock timeout shorter than that always fires first, making retry logic unreachable dead code.
+- Passing `wait=<int N>` does **not** fix it. When the long-poll expires with the prediction still `starting`, `run()` falls into `prediction.wait()`, a poll loop with **no timeout and no iteration cap**. That is exactly the accept-but-never-start pool failure we need to survive.
+- So we drive `client.predictions.create(..., wait=False)` and poll on our own clock. That is the whole reason this class looks the way it does; do not "simplify" it back to `run()`.
+
+**Replicate pools are a failover list, not a constant:**
+- `DEFAULT_FLUX_MODELS` holds canonical `flux-schnell` and the `-lora` sibling. Both have wedged at different times (2026-05: canonical wedged, `-lora` healthy; 2026-07: exactly reversed, measured). A retry moves to the **next pool** — re-rolling the same wedged pool just buys another timeout.
+- Diagnose with a 2-model probe before touching code: create one prediction per model, poll ~45s, see which ever leaves `starting`.
+
+**Two different timeouts, because "queued forever" and "slow" are different failures:**
+- `REPLICATE_STARTING_TIMEOUT_SECONDS` (15s): still in `starting` means never scheduled onto a GPU. Bail early and fail over.
+- `REPLICATE_ATTEMPT_TIMEOUT_SECONDS` (40s): once `processing` it is genuinely rendering and deserves patience. A healthy cold start measured 25s, so a tighter bound would cancel work about to succeed *and still bill for it*.
+- Abandoned predictions are **cancelled** (`prediction.cancel()`). A read timeout or wedge means the client gave up, not the prediction: it keeps running on GPU and billing until cancelled.
+- The batch backstop is **derived**, never hand-set: `(max_attempts-1)*starting + attempt + max_attempts*http_read`. A backstop below the retry budget silently makes retries unreachable, which was the original bug.
+- The backstop uses a **shared deadline** across candidates, not a fresh timeout per future. They run concurrently, so per-future timeouts let a wedged pool take `num_outputs * timeout` (4 x 60s = 4 min) to surface one error.
+
+**Retry classification — `UNRECOVERABLE_STATUSES` is deliberate:**
+- Retry: wedge, `ModelError`, `httpx.HTTPError`, 5xx, and **404**. 404 is not permanent here: Replicate returned "No adapter found for model" for a model that had succeeded minutes earlier, so it means "this pool is unreachable", which is precisely when to try the next one.
+- Do NOT retry 400/401/402/403/422/429. These are identical on every model, so failover cannot help; it only doubles doomed calls. 402 is the out-of-credit signal that needs a top-up.
+
+**Env knobs are validated, not raw `int()`:** `_env_number` falls back loudly on malformed or non-positive values. These are module-level constants, so a bare `int("25s")` would crash app startup, and `0` would disable the very bound it configures.
+
+**Testing this file:** drive a scripted API through `httpx.MockTransport` (see `FakePool` in `tests/test_images.py`), never a fake that raises instantly. The original bug lived in the SDK's control flow and 49 green tests with instant-raising fakes coexisted with a fix that did nothing in production. Also keep test attempt timeouts short: `ThreadPoolExecutor` cannot cancel running threads and joins them at exit, so a long-running abandoned attempt adds invisible wall clock that pytest's own timings do not show.
+
 ## Deep-Dive References
 - **Data model:** `docs/data-model.md`
 - **Cascade delete patterns:** `docs/solutions/cascade-patterns.md`

--- a/app/images/providers.py
+++ b/app/images/providers.py
@@ -8,10 +8,11 @@ vendor-specific exceptions.
 
 import logging
 import os
+import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FutureTimeoutError
-from typing import Callable, List, Sequence
+from typing import Callable, List, Optional, Sequence
 from urllib.parse import urlparse
 
 import anthropic
@@ -97,59 +98,190 @@ class ClaudeVisualizer:
 
 # ---------- Replicate image generator ----------
 
-# The canonical "black-forest-labs/flux-schnell" model is routed through a shared
-# pool that has periods where predictions accept-but-never-start. The "-lora" sibling
-# runs the same Flux Schnell weights on a different pool; calling it without LoRA
-# inputs produces equivalent images. It does, however, OOM on num_outputs>1, so we
-# fan out one prediction per candidate.
-DEFAULT_FLUX_MODEL = "black-forest-labs/flux-schnell-lora"
-DEFAULT_PREDICTION_TIMEOUT_SECONDS = 60.0
+# Two pools running the same Flux Schnell weights. Both have had periods of
+# accepting predictions and then never scheduling them, and crucially they fail at
+# different times: "-lora" was the workaround when the canonical pool wedged in
+# 2026-05, and by 2026-07 the positions had swapped (canonical healthy at 25s,
+# "-lora" stuck in "starting" past 45s). So we treat the model as a failover list
+# rather than a constant, and a retry moves to the *next pool* instead of re-rolling
+# the dice on the one that just failed to schedule us.
+#
+# Both are called with num_outputs=1: "-lora" OOMs above 1, and one prediction per
+# candidate is what isolates a single bad worker from the rest of the batch anyway.
+DEFAULT_FLUX_MODELS = (
+    "black-forest-labs/flux-schnell",
+    "black-forest-labs/flux-schnell-lora",
+)
+
+TERMINAL_STATUSES = frozenset({"succeeded", "failed", "canceled"})
+
+
+def _env_number(name: str, default: float, cast: Callable[[str], float]) -> float:
+    """Read a positive number from the environment, falling back loudly.
+
+    These are module-level constants, so a bad value would otherwise crash app
+    startup with a ValueError. A zero or negative value is worse than useless here:
+    it disables the very bound it configures.
+    """
+    raw = (os.getenv(name) or "").strip()
+    if not raw:
+        return default
+    try:
+        value = cast(raw)
+    except ValueError:
+        logger.warning("%s=%r is not a number; using %s", name, raw, default)
+        return default
+    if value <= 0:
+        logger.warning("%s=%r must be positive; using %s", name, raw, default)
+        return default
+    return value
+
+
+# We enforce attempt bounds ourselves rather than delegating to the SDK, because
+# replicate.run() cannot be bounded from outside: once its "Prefer: wait" window
+# expires on a prediction that is still "starting", it falls into prediction.wait(),
+# a poll loop with no timeout and no iteration cap. So we drive
+# predictions.create(wait=False) and poll on our own clock.
+#
+# Two bounds, because "queued forever" and "slow" are different problems:
+#
+# - A prediction still in "starting" has not been scheduled onto a GPU at all. That
+#   is the pool-wedge signature, and no amount of waiting fixes it, so we bail early
+#   and fail over to the other pool.
+# - Once it reaches "processing" it is genuinely rendering, and deserves real
+#   patience. A healthy cold start was measured at 25s, so a bound anywhere near
+#   that would cancel work that was about to succeed (and still bill us for it).
+DEFAULT_STARTING_TIMEOUT_SECONDS = _env_number(
+    "REPLICATE_STARTING_TIMEOUT_SECONDS", 15.0, float
+)
+DEFAULT_ATTEMPT_TIMEOUT_SECONDS = _env_number(
+    "REPLICATE_ATTEMPT_TIMEOUT_SECONDS", 40.0, float
+)
+DEFAULT_MAX_ATTEMPTS = int(_env_number("REPLICATE_MAX_ATTEMPTS", 2, lambda v: int(v)))
+
+# Caps how long any single HTTP call (create, poll, cancel) may block. The SDK's
+# default read timeout is 30s, which is far longer than a poll needs and would let
+# one wedged reload blow the attempt budget.
+DEFAULT_HTTP_READ_TIMEOUT_SECONDS = _env_number(
+    "REPLICATE_HTTP_READ_TIMEOUT_SECONDS", 10.0, float
+)
+
+
+class PredictionWedged(Exception):
+    """A prediction never reached a terminal state within its attempt budget."""
+
+
+# Account- or request-level failures: identical on every model, so failing over
+# cannot help and only doubles the doomed calls. 402 in particular is Replicate's
+# out-of-credit signal, which needs a top-up rather than another request.
+#
+# Everything else, including 404, is treated as model- or infrastructure-level and
+# is worth trying on the next pool. 404 earns its place here empirically: Replicate
+# returned "No adapter found for model" for a model that had succeeded minutes
+# earlier, so it is not the permanent "no such model" a 404 usually implies.
+UNRECOVERABLE_STATUSES = frozenset({400, 401, 402, 403, 422, 429})
+
+
+def _is_retryable(error: BaseException) -> bool:
+    """Is this worth spending another attempt (on the next model) on?"""
+    if isinstance(error, PredictionWedged):
+        return True
+    if isinstance(error, replicate.exceptions.ModelError):
+        return True  # CUDA OOM and friends; a re-roll usually lands somewhere healthy
+    if isinstance(error, replicate.exceptions.ReplicateError):
+        status = getattr(error, "status", None)
+        if not isinstance(status, int):
+            return False
+        return status not in UNRECOVERABLE_STATUSES
+    if isinstance(error, httpx.HTTPError):
+        return True  # read timeout, connection reset: transport-level, not semantic
+    return False
 
 
 class ReplicateImageGenerator:
     """Generates candidates via parallel Flux Schnell predictions.
 
-    Each candidate is its own prediction with ``num_outputs=1``. This isolates failures
-    (a single CUDA OOM or stuck worker costs one candidate, not the whole batch) and
-    lets us put a wall-clock timeout around each call so the request can never hang.
+    Each candidate is its own prediction with ``num_outputs=1``, so a single CUDA OOM
+    or stuck worker costs one candidate rather than the whole batch.
+
+    Time is bounded at three levels, and the ordering is the invariant:
+
+    1. ``starting_timeout_seconds`` catches a pool that accepted the prediction but
+       never scheduled it. On expiry we cancel and fail over to the next model.
+    2. ``attempt_timeout_seconds`` bounds an attempt that *is* rendering. We create
+       non-blocking and poll ourselves, so this is a real bound rather than a
+       request we hope the SDK honors. On expiry the prediction is cancelled;
+       otherwise it keeps running on GPU and billing.
+    3. ``timeout_seconds`` is a batch-wide wall-clock backstop, derived from (2) and
+       ``max_attempts`` so it cannot be configured below the retry budget. It is a
+       last resort: Python cannot cancel a running thread, so if a worker thread
+       wedges anyway this is what lets the request return.
     """
 
     def __init__(
         self,
-        model: str = DEFAULT_FLUX_MODEL,
+        models: Sequence[str] = DEFAULT_FLUX_MODELS,
         aspect_ratio: str = "1:1",
         num_outputs: int = 4,
-        timeout_seconds: float = DEFAULT_PREDICTION_TIMEOUT_SECONDS,
-        runner: Callable[..., list] = replicate.run,
+        timeout_seconds: Optional[float] = None,
+        starting_timeout_seconds: float = DEFAULT_STARTING_TIMEOUT_SECONDS,
+        attempt_timeout_seconds: float = DEFAULT_ATTEMPT_TIMEOUT_SECONDS,
+        max_attempts: int = DEFAULT_MAX_ATTEMPTS,
+        http_read_timeout_seconds: float = DEFAULT_HTTP_READ_TIMEOUT_SECONDS,
+        client: Optional[replicate.Client] = None,
     ) -> None:
-        self._model = model
+        if not models:
+            raise ValueError("models must not be empty")
+        self._models = tuple(models)
+        self._starting_timeout_seconds = starting_timeout_seconds
         self._aspect_ratio = aspect_ratio
         self._num_outputs = num_outputs
-        self._timeout_seconds = timeout_seconds
-        self._runner = runner
+        self._attempt_timeout_seconds = attempt_timeout_seconds
+        self._max_attempts = max_attempts
+        self._http_read_timeout_seconds = http_read_timeout_seconds
+        self._client = client
+        # Worst realistic path: every attempt but the last gives up early as wedged,
+        # and the last one runs its full budget. Each attempt can also overrun by at
+        # most one in-flight HTTP call. Derived rather than hand-set, because a
+        # backstop shorter than the retry budget silently makes retries unreachable,
+        # which is the bug this class was rewritten to fix.
+        self._timeout_seconds = (
+            timeout_seconds
+            if timeout_seconds is not None
+            else (
+                (max_attempts - 1) * starting_timeout_seconds
+                + attempt_timeout_seconds
+                + max_attempts * http_read_timeout_seconds
+            )
+        )
 
     def generate(self, prompt: str) -> List[str]:
-        if not os.getenv("REPLICATE_API_TOKEN"):
-            raise ImageGenerationError("REPLICATE_API_TOKEN is not set")
+        client = self._get_client()
 
         pool = ThreadPoolExecutor(max_workers=self._num_outputs)
         try:
             futures = [
-                pool.submit(self._generate_one, prompt)
+                pool.submit(self._generate_one, client, prompt)
                 for _ in range(self._num_outputs)
             ]
             urls: List[str] = []
             errors: List[str] = []
+            # One deadline shared across all candidates. They were all submitted at
+            # once and run concurrently, so the budget is batch-wide: giving each
+            # future its own fresh timeout would let a fully-wedged pool take
+            # num_outputs * timeout (4 * 60s = 4 minutes) to surface one error.
+            deadline = time.monotonic() + self._timeout_seconds
             for future in futures:
+                remaining = max(0.0, deadline - time.monotonic())
                 try:
-                    urls.append(future.result(timeout=self._timeout_seconds))
+                    urls.append(future.result(timeout=remaining))
                 except FutureTimeoutError:
-                    errors.append(f"timed out after {self._timeout_seconds:.0f}s")
+                    errors.append(f"gave up waiting after {remaining:.0f}s")
                 except ImageGenerationError as e:
                     errors.append(str(e))
         finally:
-            # Don't block returning to the user on slow stragglers; they'll finish
-            # in their own time and the threadpool is GC'd.
+            # Can't stop threads already running; cancel_futures only drops queued
+            # work. Stragglers finish on their own and cancel their own predictions.
             pool.shutdown(wait=False, cancel_futures=True)
 
         if not urls:
@@ -167,40 +299,118 @@ class ReplicateImageGenerator:
             )
         return urls
 
-    def _generate_one(self, prompt: str) -> str:
-        # ModelError (CUDA OOM, transient prediction failures) is a sibling of
-        # ReplicateError under ReplicateException — catch the base so we don't 500
-        # on shared-GPU saturation. Retry once on ModelError: the next attempt
-        # routes to a different worker and almost always succeeds.
-        last_error: Exception | None = None
-        for attempt in range(2):
+    def _get_client(self) -> replicate.Client:
+        if self._client is not None:
+            return self._client
+        token = os.getenv("REPLICATE_API_TOKEN")
+        if not token:
+            raise ImageGenerationError("REPLICATE_API_TOKEN is not set")
+        self._client = replicate.Client(
+            api_token=token,
+            timeout=httpx.Timeout(
+                5.0,
+                connect=5.0,
+                read=self._http_read_timeout_seconds,
+                write=self._http_read_timeout_seconds,
+                pool=10.0,
+            ),
+        )
+        return self._client
+
+    def _generate_one(self, client: replicate.Client, prompt: str) -> str:
+        last_error: Optional[BaseException] = None
+        for attempt in range(1, self._max_attempts + 1):
+            # Move to the next pool on each retry. When a pool wedges it stops
+            # scheduling *everything*, so re-rolling against the same one just buys
+            # another timeout; the other pool is usually healthy at that moment.
+            model = self._models[(attempt - 1) % len(self._models)]
             try:
-                output = self._runner(
-                    self._model,
-                    input={
-                        "prompt": prompt,
-                        "num_outputs": 1,
-                        "aspect_ratio": self._aspect_ratio,
-                        "output_format": "webp",
-                        "output_quality": 90,
-                    },
-                )
-            except replicate.exceptions.ModelError as e:
+                return self._run_attempt(client, prompt, model)
+            except (
+                PredictionWedged,
+                replicate.exceptions.ReplicateException,
+                httpx.HTTPError,
+            ) as e:
+                if not _is_retryable(e):
+                    raise ImageGenerationError(f"Replicate error: {e}") from e
                 last_error = e
-                logger.warning("Replicate ModelError on attempt %d: %s", attempt + 1, e)
-                continue
-            except replicate.exceptions.ReplicateException as e:
-                raise ImageGenerationError(f"Replicate error: {e}") from e
-            except httpx.HTTPError as e:
-                raise ImageGenerationError(f"Network error: {e}") from e
+                logger.warning(
+                    "Replicate attempt %d/%d on %s failed (%s): %s",
+                    attempt, self._max_attempts, model, type(e).__name__, e,
+                )
 
-            items = list(output)
-            if not items:
-                raise ImageGenerationError("Replicate returned empty output")
-            item = items[0]
-            return str(item.url) if hasattr(item, "url") else str(item)
+        raise ImageGenerationError(
+            f"Failed after {self._max_attempts} attempts: {last_error}"
+        ) from last_error
 
-        raise ImageGenerationError(f"Replicate model error after retry: {last_error}") from last_error
+    def _run_attempt(self, client: replicate.Client, prompt: str, model: str) -> str:
+        prediction = client.predictions.create(
+            model=model,
+            input={
+                "prompt": prompt,
+                "num_outputs": 1,
+                "aspect_ratio": self._aspect_ratio,
+                "output_format": "webp",
+                "output_quality": 90,
+            },
+            wait=False,
+        )
+
+        started = time.monotonic()
+        scheduling_deadline = started + self._starting_timeout_seconds
+        attempt_deadline = started + self._attempt_timeout_seconds
+        while prediction.status not in TERMINAL_STATUSES:
+            now = time.monotonic()
+            # Read the status before cancelling; cancel() overwrites it.
+            stuck_at = prediction.status
+            if stuck_at == "starting" and now >= scheduling_deadline:
+                self._abandon(prediction)
+                raise PredictionWedged(
+                    f"{model} never left 'starting' within "
+                    f"{self._starting_timeout_seconds:.0f}s"
+                )
+            if now >= attempt_deadline:
+                self._abandon(prediction)
+                raise PredictionWedged(
+                    f"{model} still {stuck_at} after "
+                    f"{self._attempt_timeout_seconds:.0f}s"
+                )
+            time.sleep(client.poll_interval)
+            prediction.reload()
+
+        if prediction.status == "failed":
+            # Matches replicate.run()'s own handling; ModelError is retryable.
+            raise replicate.exceptions.ModelError(prediction)
+        if prediction.status == "canceled":
+            raise ImageGenerationError("Prediction was canceled")
+
+        return self._extract_url(prediction.output)
+
+    def _abandon(self, prediction) -> None:  # type: ignore[no-untyped-def]
+        """Cancel a prediction we have given up on so it stops billing.
+
+        Best effort by design: this runs while we are already failing, and a cleanup
+        error must never replace the error we actually want to report.
+        """
+        try:
+            prediction.cancel()
+        except Exception as e:  # noqa: BLE001
+            logger.warning(
+                "Could not cancel abandoned prediction %s: %s",
+                getattr(prediction, "id", "?"), e,
+            )
+
+    @staticmethod
+    def _extract_url(output: object) -> str:
+        # A prediction can report "succeeded" with no output attached; guard rather
+        # than let list(None) raise TypeError, which would escape as a 500.
+        if output is None:
+            raise ImageGenerationError("Replicate returned no output")
+        items = list(output) if isinstance(output, (list, tuple)) else [output]
+        if not items:
+            raise ImageGenerationError("Replicate returned empty output")
+        item = items[0]
+        return str(item.url) if hasattr(item, "url") else str(item)
 
 
 # ---------- R2 image store ----------

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -6,6 +6,7 @@ Three layers, each tested in isolation:
 - __init__.py: the factory wires prod deps; covered by endpoint tests
 """
 
+import time
 from typing import List, Sequence
 from unittest.mock import MagicMock
 
@@ -236,6 +237,115 @@ def test_claude_visualizer_rejects_whitespace_only_response():
 
 
 # ========== ReplicateImageGenerator ==========
+#
+# These drive a scripted Replicate API through httpx.MockTransport rather than
+# stubbing our own call site. That matters: the bug this class was rewritten to fix
+# lived in the SDK's control flow (an unbounded poll loop reached only after a
+# long-poll expired), and a fake that raises instantly can never reproduce it.
+
+
+def _pred_json(pid: str, status: str, output=None, error=None) -> dict:
+    return {
+        "id": pid,
+        "model": "black-forest-labs/flux-schnell-lora",
+        "version": "v1",
+        "status": status,
+        "input": {"prompt": "x"},
+        "output": output,
+        "error": error,
+        "logs": "",
+        "created_at": "2026-07-21T00:00:00Z",
+        "urls": {
+            "get": f"https://api.replicate.com/v1/predictions/{pid}",
+            "cancel": f"https://api.replicate.com/v1/predictions/{pid}/cancel",
+        },
+    }
+
+
+class FakePool:
+    """A scripted Replicate API.
+
+    Each ``create`` consumes the next plan (the last plan repeats). A plan is either
+    an int HTTP status to fail the create with, or a dict of
+    ``{"statuses": [...], "output": [...]}`` where successive polls walk the status
+    list and the final entry repeats forever (that is how a wedged pool is modeled).
+    """
+
+    def __init__(self, *plans):
+        self.plans = list(plans) or [{"statuses": ["succeeded"], "output": ["https://r/x.webp"]}]
+        self.creates = 0
+        self.polls = 0
+        self.cancels: List[str] = []
+        self.bodies: List[dict] = []
+        self.headers: List[dict] = []
+        self.models: List[str] = []
+        self._live: dict = {}
+
+    def handler(self, request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if request.method == "POST" and path.endswith("/cancel"):
+            pid = path.split("/")[-2]
+            self.cancels.append(pid)
+            return httpx.Response(200, json=_pred_json(pid, "canceled"))
+        if request.method == "POST":
+            return self._create(request)
+        if request.method == "GET":
+            self.polls += 1
+            return self._get(path.rsplit("/", 1)[-1])
+        return httpx.Response(405, json={"detail": f"unexpected {request.method}"})
+
+    def _create(self, request: httpx.Request) -> httpx.Response:
+        import json as _json
+        self.bodies.append(_json.loads(request.content or b"{}"))
+        self.headers.append(dict(request.headers))
+        # /v1/models/{owner}/{name}/predictions
+        self.models.append(
+            request.url.path.removeprefix("/v1/models/").removesuffix("/predictions")
+        )
+        plan = self.plans[min(self.creates, len(self.plans) - 1)]
+        self.creates += 1
+        if isinstance(plan, int):
+            return httpx.Response(plan, json={"detail": "scripted failure"})
+        pid = f"p{self.creates}"
+        self._live[pid] = {
+            "statuses": list(plan["statuses"]),
+            "output": plan.get("output"),
+        }
+        return httpx.Response(201, json=self._render(pid))
+
+    def _advance(self, pid: str) -> str:
+        statuses = self._live[pid]["statuses"]
+        return statuses.pop(0) if len(statuses) > 1 else statuses[0]
+
+    def _render(self, pid: str) -> dict:
+        status = self._advance(pid)
+        output = self._live[pid]["output"] if status == "succeeded" else None
+        return _pred_json(pid, status, output)
+
+    def _get(self, pid: str) -> httpx.Response:
+        return httpx.Response(200, json=self._render(pid))
+
+
+def _generator(pool: "FakePool", **kwargs) -> ReplicateImageGenerator:
+    import replicate
+    client = replicate.Client(
+        api_token="fake", transport=httpx.MockTransport(pool.handler)
+    )
+    client.poll_interval = 0.01
+    kwargs.setdefault("num_outputs", 1)
+    kwargs.setdefault("starting_timeout_seconds", 0.2)
+    kwargs.setdefault("attempt_timeout_seconds", 0.4)
+    kwargs.setdefault("http_read_timeout_seconds", 0.3)
+    return ReplicateImageGenerator(client=client, **kwargs)
+
+
+SUCCESS = {"statuses": ["succeeded"], "output": ["https://r/ok.webp"]}
+WEDGED = {"statuses": ["starting"]}  # never leaves "starting" — the real failure mode
+# Reaches a GPU and renders, just not instantly. Must NOT be killed as wedged.
+SLOW_BUT_ALIVE = {
+    "statuses": ["starting", "processing", "processing", "processing", "succeeded"],
+    "output": ["https://r/slow.webp"],
+}
 
 
 def test_replicate_generator_missing_token(monkeypatch):
@@ -245,133 +355,235 @@ def test_replicate_generator_missing_token(monkeypatch):
         generator.generate("prompt")
 
 
-def test_replicate_generator_fans_out_one_call_per_candidate(monkeypatch):
-    """Each candidate is its own prediction with num_outputs=1 — avoids GPU OOM."""
-    monkeypatch.setenv("REPLICATE_API_TOKEN", "fake")
-    counter = {"n": 0}
+def test_wedged_prediction_is_cancelled_and_retried():
+    """THE regression test.
 
-    def fake_runner(model, input):
-        counter["n"] += 1
-        return [f"https://r/{counter['n']}.webp"]
+    A pool that accepts predictions but never starts them is the documented failure
+    mode. Previously replicate.run() would block in an unbounded poll loop here, so
+    the retry never fired and the abandoned prediction kept billing. Now: two
+    creates (the retry ran) and two cancels (neither orphan was left running).
+    """
+    pool = FakePool(WEDGED, WEDGED)
+    generator = _generator(pool, max_attempts=2)
 
-    generator = ReplicateImageGenerator(runner=fake_runner, num_outputs=4)
+    with pytest.raises(ImageGenerationError, match="All 1 candidates failed"):
+        generator.generate("prompt")
+
+    assert pool.creates == 2, "retry did not fire against a wedged pool"
+    assert len(pool.cancels) == 2, "abandoned predictions were left billing"
+
+
+def test_wedged_first_attempt_then_healthy_worker_succeeds():
+    """The whole point of retrying: re-roll off a stuck worker onto a good one."""
+    pool = FakePool(WEDGED, SUCCESS)
+    generator = _generator(pool, max_attempts=2)
+
+    assert generator.generate("prompt") == ["https://r/ok.webp"]
+    assert pool.creates == 2
+    assert pool.cancels == ["p1"]
+
+
+def test_wedged_pool_fails_over_to_the_next_model():
+    """A wedged pool stops scheduling everything, so retrying it is pointless.
+
+    Observed 2026-07-21: flux-schnell-lora stuck in "starting" past 45s while the
+    canonical pool succeeded in 25s. In 2026-05 the positions were reversed. The
+    retry must change pools, not just re-roll.
+    """
+    pool = FakePool(WEDGED, SUCCESS)
+    generator = _generator(
+        pool,
+        models=["pool-a/model", "pool-b/model"],
+        max_attempts=2,
+    )
+
+    assert generator.generate("prompt") == ["https://r/ok.webp"]
+    assert pool.models == ["pool-a/model", "pool-b/model"], "retry reused the bad pool"
+
+
+def test_slow_but_processing_prediction_is_not_killed_as_wedged():
+    """"Queued forever" and "slow" are different failures.
+
+    A healthy cold start was measured at 25s. Treating that as wedged would cancel
+    work about to succeed, and still bill for it.
+    """
+    pool = FakePool(SLOW_BUT_ALIVE)
+    generator = _generator(
+        pool,
+        starting_timeout_seconds=0.05,  # would fire immediately if status were ignored
+        attempt_timeout_seconds=5.0,
+        max_attempts=1,
+    )
+
+    assert generator.generate("prompt") == ["https://r/slow.webp"]
+    assert pool.cancels == [], "cancelled a prediction that was actively processing"
+
+
+def test_wedged_batch_stays_within_the_wall_clock_backstop():
+    pool = FakePool(WEDGED)
+    generator = _generator(
+        pool, num_outputs=4, max_attempts=2, attempt_timeout_seconds=0.2
+    )
+    started = time.monotonic()
+    with pytest.raises(ImageGenerationError):
+        generator.generate("prompt")
+    elapsed = time.monotonic() - started
+    assert elapsed < generator._timeout_seconds + 1.0
+
+
+@pytest.mark.parametrize("status", [400, 401, 402, 403, 422, 429])
+def test_account_level_errors_are_not_retried(status):
+    """Retrying a bad token, exhausted credit, or bad input cannot succeed.
+
+    These are identical on every model, so failing over cannot help. It only
+    doubles the doomed calls (4 candidates x 2 attempts = 8) and doubles
+    time-to-error. 429 is included deliberately: Replicate's documented throttle
+    below $5 credit needs a top-up, not another request.
+    """
+    pool = FakePool(status)
+    generator = _generator(pool, max_attempts=2)
+
+    with pytest.raises(ImageGenerationError):
+        generator.generate("prompt")
+
+    assert pool.creates == 1, f"HTTP {status} should not be retried"
+
+
+@pytest.mark.parametrize("status", [404, 500, 502, 503])
+def test_model_and_infrastructure_errors_fail_over(status):
+    """404 belongs here, not with the permanent errors.
+
+    Observed live 2026-07-21: Replicate returned "No adapter found for model" for a
+    model that had succeeded minutes earlier. In a failover list a 404 means "this
+    pool is unreachable", which is precisely when the next one should be tried.
+    """
+    pool = FakePool(status, SUCCESS)
+    generator = _generator(pool, max_attempts=2)
+
+    assert generator.generate("prompt") == ["https://r/ok.webp"]
+    assert pool.creates == 2
+
+
+def test_failed_prediction_is_retried_on_a_new_worker():
+    """A "failed" status is the CUDA-OOM shape; a re-roll usually lands healthy."""
+    pool = FakePool({"statuses": ["failed"]}, SUCCESS)
+    generator = _generator(pool, max_attempts=2)
+
+    assert generator.generate("prompt") == ["https://r/ok.webp"]
+    assert pool.creates == 2
+
+
+def test_succeeded_with_null_output_is_a_clean_error_not_a_crash():
+    """Guards a 500. A prediction can report success with output=None; list(None)
+    would raise TypeError, which api.py does not catch."""
+    pool = FakePool({"statuses": ["succeeded"], "output": None})
+    generator = _generator(pool, max_attempts=1)
+
+    with pytest.raises(ImageGenerationError, match="no output"):
+        generator.generate("prompt")
+
+
+def test_generator_fans_out_one_prediction_per_candidate():
+    pool = FakePool(SUCCESS)
+    generator = _generator(pool, num_outputs=4)
+
     urls = generator.generate("a scene")
 
     assert len(urls) == 4
-    assert counter["n"] == 4
-    assert set(urls) == {f"https://r/{i}.webp" for i in range(1, 5)}
+    assert pool.creates == 4
 
 
-def test_replicate_generator_sends_correct_input_shape(monkeypatch):
-    monkeypatch.setenv("REPLICATE_API_TOKEN", "fake")
-    fake_runner = MagicMock(return_value=["https://r/1.webp"])
-    generator = ReplicateImageGenerator(runner=fake_runner, num_outputs=1)
+def test_generator_sends_correct_input_shape_and_does_not_block_on_create():
+    pool = FakePool(SUCCESS)
+    generator = _generator(pool)
 
     generator.generate("a scene")
 
-    call_input = fake_runner.call_args.kwargs["input"]
-    assert call_input["prompt"] == "a scene"
-    assert call_input["num_outputs"] == 1
-    assert call_input["aspect_ratio"] == "1:1"
-    assert call_input["output_format"] == "webp"
+    body = pool.bodies[0]
+    assert body["input"]["prompt"] == "a scene"
+    assert body["input"]["num_outputs"] == 1
+    assert body["input"]["aspect_ratio"] == "1:1"
+    assert body["input"]["output_format"] == "webp"
+    # wait=False must not become a long-poll: we own the polling now.
+    assert "Prefer" not in pool.headers[0]
 
 
-def test_replicate_generator_handles_fileoutput_objects(monkeypatch):
-    monkeypatch.setenv("REPLICATE_API_TOKEN", "fake")
-    item = MagicMock()
-    item.url = "https://r/1.webp"
-    fake_runner = MagicMock(return_value=[item])
-    generator = ReplicateImageGenerator(runner=fake_runner, num_outputs=1)
+def test_generator_returns_partial_results_when_some_candidates_fail():
+    """Degraded beats dead: one bad candidate must not fail the whole batch."""
+    pool = FakePool(SUCCESS, 422, SUCCESS, SUCCESS)
+    generator = _generator(pool, num_outputs=4, max_attempts=1)
 
-    assert generator.generate("prompt") == ["https://r/1.webp"]
+    assert len(generator.generate("prompt")) == 3
 
 
-def test_replicate_generator_returns_partial_results_when_some_calls_fail(monkeypatch):
-    """One bad candidate shouldn't fail the whole batch — degraded is better than dead."""
-    import replicate.exceptions
-    monkeypatch.setenv("REPLICATE_API_TOKEN", "fake")
-    counter = {"n": 0}
+def test_generator_handles_fileoutput_style_objects():
+    class _FileOutput:
+        url = "https://r/from-object.webp"
 
-    def flaky_runner(model, input):
-        counter["n"] += 1
-        if counter["n"] == 2:
-            raise replicate.exceptions.ReplicateError("CUDA OOM on this one")
-        return [f"https://r/{counter['n']}.webp"]
-
-    generator = ReplicateImageGenerator(runner=flaky_runner, num_outputs=4)
-    urls = generator.generate("prompt")
-    assert len(urls) == 3
+    assert ReplicateImageGenerator._extract_url([_FileOutput()]) == "https://r/from-object.webp"
 
 
-def test_replicate_generator_raises_when_all_calls_fail(monkeypatch):
-    import replicate.exceptions
-    monkeypatch.setenv("REPLICATE_API_TOKEN", "fake")
-    broken = MagicMock(side_effect=replicate.exceptions.ReplicateError("upstream 502"))
-    generator = ReplicateImageGenerator(runner=broken, num_outputs=4)
+def test_batch_timeout_is_shared_not_per_candidate():
+    """Candidates run concurrently, so the budget is batch-wide. Per-future
+    timeouts would let a wedged pool burn num_outputs * timeout.
+
+    max_attempts=1 and a modest attempt timeout keep the abandoned worker threads
+    short-lived: they cannot be cancelled, and ThreadPoolExecutor joins them at
+    interpreter exit, so an over-long attempt here would add invisible wall clock
+    to every CI run without showing up in pytest's own timings.
+    """
+    pool = FakePool(WEDGED)
+    generator = _generator(
+        pool,
+        num_outputs=4,
+        timeout_seconds=0.3,
+        attempt_timeout_seconds=1.5,
+        max_attempts=1,
+    )
+    started = time.monotonic()
     with pytest.raises(ImageGenerationError, match="All 4 candidates failed"):
         generator.generate("prompt")
+    elapsed = time.monotonic() - started
+    assert elapsed < 2.0, f"batch took {elapsed:.1f}s — timeout is not shared"
 
 
-def _make_model_error(msg: str):
-    """ModelError takes a Prediction-like object whose .error it reports."""
-    import replicate.exceptions
-    stub = type("PredictionStub", (), {"error": msg})()
-    return replicate.exceptions.ModelError(stub)
-
-
-def test_replicate_generator_retries_once_on_model_error(monkeypatch):
-    """CUDA OOM lands on a random worker — one retry usually picks a healthy one."""
-    import replicate.exceptions
-    monkeypatch.setenv("REPLICATE_API_TOKEN", "fake")
-    calls = {"n": 0}
-
-    def oom_then_ok(model, input):
-        calls["n"] += 1
-        if calls["n"] == 1:
-            raise _make_model_error("CUDA out of memory")
-        return ["https://r/ok.webp"]
-
-    generator = ReplicateImageGenerator(runner=oom_then_ok, num_outputs=1)
-    urls = generator.generate("prompt")
-    assert urls == ["https://r/ok.webp"]
-    assert calls["n"] == 2  # one failure, one retry
-
-
-def test_replicate_generator_gives_up_after_repeated_model_errors(monkeypatch):
-    """If the retry also OOMs, the candidate is a clean failure (not a 500)."""
-    import replicate.exceptions
-    monkeypatch.setenv("REPLICATE_API_TOKEN", "fake")
-    persistent_oom = MagicMock(
-        side_effect=_make_model_error("CUDA out of memory")
-    )
-    generator = ReplicateImageGenerator(runner=persistent_oom, num_outputs=1)
-    with pytest.raises(ImageGenerationError, match="model error after retry"):
-        generator.generate("prompt")
-    assert persistent_oom.call_count == 2  # initial + one retry
-
-
-def test_replicate_generator_times_out_stuck_predictions(monkeypatch):
-    """A wedged Replicate prediction must not hang the request forever."""
-    import time
-    monkeypatch.setenv("REPLICATE_API_TOKEN", "fake")
-
-    def slow_runner(model, input):
-        time.sleep(5)  # would hang forever in the real failure mode
-        return ["never seen"]
-
+def test_backstop_is_derived_to_fit_the_full_retry_budget():
+    """Worst realistic path: N-1 attempts bail early as wedged, the last runs full."""
     generator = ReplicateImageGenerator(
-        runner=slow_runner, num_outputs=2, timeout_seconds=0.1
+        starting_timeout_seconds=15,
+        attempt_timeout_seconds=40,
+        http_read_timeout_seconds=10,
+        max_attempts=2,
     )
-    with pytest.raises(ImageGenerationError, match="timed out"):
-        generator.generate("prompt")
+    assert generator._timeout_seconds == 15 + 40 + 20
 
 
-def test_replicate_generator_wraps_http_errors(monkeypatch):
-    monkeypatch.setenv("REPLICATE_API_TOKEN", "fake")
-    broken = MagicMock(side_effect=httpx.ConnectError("timeout"))
-    generator = ReplicateImageGenerator(runner=broken, num_outputs=1)
-    with pytest.raises(ImageGenerationError, match="Network error"):
-        generator.generate("prompt")
+def test_explicit_timeout_overrides_the_derived_backstop():
+    generator = ReplicateImageGenerator(timeout_seconds=3.0, max_attempts=2)
+    assert generator._timeout_seconds == 3.0
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        (None, 20.0),      # unset
+        ("", 20.0),        # empty
+        ("   ", 20.0),     # whitespace
+        ("25s", 20.0),     # malformed: would crash app startup if it raised
+        ("0", 20.0),       # zero would disable the bound entirely
+        ("-5", 20.0),      # negative is nonsense
+        ("30", 30.0),      # valid
+    ],
+)
+def test_env_number_rejects_values_that_would_disable_the_bound(monkeypatch, raw, expected):
+    from app.images.providers import _env_number
+
+    if raw is None:
+        monkeypatch.delenv("SOME_KNOB", raising=False)
+    else:
+        monkeypatch.setenv("SOME_KNOB", raw)
+
+    assert _env_number("SOME_KNOB", 20.0, float) == expected
 
 
 # ========== R2ImageStore ==========


### PR DESCRIPTION
## The bug

Theme cover image generation returned 503s (`All 4 candidates failed: timed out after 60s`) that no retry could fix. Not a billing issue: the account had $14.42 credit.

## Two root causes

**1. `replicate.run()` cannot be bounded from outside.** When a prediction stays in `starting`, `run()` falls into `prediction.wait()`, a poll loop with no timeout and no iteration cap. Any wall-clock timeout wrapped around it fires first, so the existing retry logic was unreachable dead code. Reproduced with a `MockTransport` that never leaves `starting`: 1 POST, 11 polls, still blocked.

**2. The two Flux Schnell pools swap health over time.** The code pinned `-lora` because the canonical pool was wedged in 2026-05. Measured 2026-07-22, one prediction each:

```
black-forest-labs/flux-schnell-lora : WEDGED, still "starting" after 45s
black-forest-labs/flux-schnell      : succeeded in 1.3s
```

Exactly reversed. So even a correctly bounded retry recovered nothing, because it re-rolled the same dead pool.

## Changes

- Drive `predictions.create(wait=False)` and poll on our own deadline, so the per-attempt bound is real.
- **Cancel abandoned predictions.** A timeout means the client gave up, not the prediction: it keeps running on GPU and billing until cancelled.
- Treat the model as a **failover list**; a retry advances to the next pool.
- **Two bounds, not one**, because "queued forever" and "slow" differ: 15s for never leaving `starting` (never scheduled, bail and fail over), 40s for one actively `processing` (a healthy cold start measured 25s, so a tighter bound would cancel work about to succeed and still bill for it).
- Classify errors: retry wedge / `ModelError` / network / 5xx / **404**; never 400/401/402/403/422/429. 404 earns retry empirically, Replicate returned "No adapter found" for a model that had worked minutes earlier.
- Share one deadline across candidates. They run concurrently, so per-future timeouts let a wedged pool take `num_outputs * timeout` (4 x 60s = 4 min) to surface one error. Pre-existing bug.
- Validate env knobs. A bare `int()` crashes app startup on a malformed value, and `0` silently disables the bound it configures.
- Guard succeeded-with-null-output, which raised `TypeError` and escaped as a 500 rather than a graceful 503.

## Verification

- 226 tests pass. Suite wall time **24s to 4.6s** (abandoned worker threads were being joined at exit, invisible to pytest's own timings).
- Tests now drive a scripted Replicate API through `httpx.MockTransport`. The previous fakes raised instantly and were structurally unable to reproduce a timing bug, which is how a green suite coexisted with a fix that did nothing.
- **Live against the genuinely wedged pool:** 3/4 candidates in 15.6s on production defaults; failover recovered in 16.8s.

## Note

Replicate was intermittently degraded throughout testing, occasionally both pools at once. This makes generation work whenever at least one pool is healthy, and fail fast with an accurate message when neither is. It cannot manufacture capacity Replicate is not providing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)