### PR TITLE
chore: replace Nixpacks build with a pinned, reproducible Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,36 @@
+# Keep the build context small and deterministic. Anything the image builds itself
+# (node_modules, dist, .venv) or that is host-only (envs, git, caches, tests) is
+# excluded so it can never leak into a layer or bust the cache.
+
+.git
+.github
+.gitignore
+
+# Python
+.venv
+venv
+__pycache__
+**/__pycache__
+*.pyc
+.pytest_cache
+.ruff_cache
+tests
+
+# Node / frontend build artifacts (rebuilt inside the frontend stage)
+frontend/node_modules
+frontend/dist
+
+# Local env + secrets (Railway injects these at runtime)
+.env
+.env.*
+!.env.example
+
+# Tooling / docs / agent scratch not needed at runtime
+.llm
+.claude
+docs
+mise.toml
+nixpacks.toml
+README.dev.md
+*.md
+!README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,59 @@
+# syntax=docker/dockerfile:1
+#
+# Reproducible production image for the breadcrumbs polyglot app (FastAPI backend +
+# Vite/React frontend). Every tool version is pinned here in-repo so the build can
+# never silently drift the way the previous Nixpacks setup did (it defaulted to
+# Node 18 and stayed broken for two months). No corepack: pnpm is installed
+# directly at its pinned version, which sidesteps corepack's signing-key
+# verification entirely rather than disabling it.
+
+# ---------- Stage 1: build the frontend ----------
+FROM node:22-slim AS frontend
+
+WORKDIR /build
+
+# pnpm pinned to the exact version in frontend/package.json's packageManager field.
+RUN npm install --global pnpm@10.33.0
+
+# Install dependencies first, on just the manifest + lockfile, so this layer is
+# cached until the dependency set actually changes.
+COPY frontend/package.json frontend/pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+# Build the SPA. `pnpm build` runs `tsc -b && vite build`, emitting to /build/dist.
+COPY frontend/ ./
+RUN pnpm build
+
+# ---------- Stage 2: python runtime ----------
+FROM python:3.13-slim AS runtime
+
+# uv pinned to match the version the project builds with; copied from the official
+# uv image so we never fetch-and-hope at build time.
+COPY --from=ghcr.io/astral-sh/uv:0.8.12 /uv /uvx /bin/
+
+WORKDIR /app
+
+# Compile bytecode for faster cold starts; copy (not hardlink) since the build
+# context and venv live on different layers.
+ENV UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy
+
+# Resolve dependencies from the lockfile before copying the app source, so a code
+# change doesn't invalidate the (slow) dependency layer.
+COPY pyproject.toml uv.lock README.md ./
+RUN uv sync --frozen --no-dev --no-install-project
+
+# Backend source + migration assets. STATIC_DIR in app/api.py resolves to
+# <app parent>/frontend/dist, i.e. /app/frontend/dist, so the built SPA lands there.
+COPY app/ ./app/
+COPY alembic/ ./alembic/
+COPY alembic.ini main.py ./
+COPY --from=frontend /build/dist ./frontend/dist
+
+# Install the project itself now that its package source is present.
+RUN uv sync --frozen --no-dev
+
+# Railway injects PORT and every secret/config var (ENVIRONMENT, DATABASE_URL, R2_*,
+# ANTHROPIC_API_KEY, REPLICATE_API_TOKEN, ...) at runtime, so none are baked in here.
+# Migrations run on start; then the app boots. main.py reads PORT and binds 0.0.0.0.
+CMD ["sh", "-c", "uv run alembic upgrade head && uv run python main.py"]

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,1 +1,0 @@
-providers = ["python", "node"]

--- a/railway.toml
+++ b/railway.toml
@@ -1,6 +1,7 @@
 [build]
-builder = "nixpacks"
-buildCommand = "cd frontend && corepack enable && pnpm install --frozen-lockfile && pnpm run build && cd .. && uv sync"
+builder = "dockerfile"
+dockerfilePath = "Dockerfile"
 
-[deploy]
-startCommand = "uv run alembic upgrade head && uv run python main.py"
+# How the container starts (migrations, then boot) lives in the Dockerfile CMD, so
+# there is a single source of truth reproducible with a plain `docker run`. Every
+# tool version is pinned in the Dockerfile; nothing is inferred at build time.


### PR DESCRIPTION
## Why

The Nixpacks build silently broke deploys for ~2 months. Three pieces of tech debt, now erased:

1. **Nixpacks guessed the environment and picked Node 18**, but Vite 7 needs ≥ 20.19. Nothing in the repo pinned it (`mise.toml` isn't read by the builder), so it failed invisibly.
2. **`corepack enable` fails with "Cannot find matching keyid"**: the bundled corepack ships npm signing keys npm has since rotated. The only way past it was `COREPACK_INTEGRITY_KEYS=0`, i.e. disabling signature verification. A band-aid on a security check.
3. **Node and uv versions lived only as Railway env vars** (`NIXPACKS_NODE_VERSION`, `NIXPACKS_UV_VERSION`), invisible in the repo and not reproducible locally.

## What

A multi-stage `Dockerfile` where every version is pinned in-repo:

- **Node 22**, **pnpm 10.33.0** installed directly (no corepack, so there's no signing-key check to disable in the first place)
- **Python 3.13**, **uv 0.8.12** (copied from the official uv image, not fetched at build time)
- Frontend built in stage 1, served from `/app/frontend/dist` exactly where `app/api.py` expects it
- Runtime config (PORT, ENVIRONMENT, DATABASE_URL, secrets) stays injected by Railway; nothing sensitive is baked into the image

`railway.toml` switches `builder` to `dockerfile`; `nixpacks.toml` is deleted.

## Validation

Built and ran locally end to end **against Postgres** (the real production path, not SQLite):

- All 9 Alembic migrations apply
- App boots, Uvicorn serves
- `/api/themes` returns JSON `[]` (API routing intact, not the SPA fallback)
- SPA root + hashed JS asset served (200), and unknown non-API paths fall back to the SPA index for client-side routing

## Follow-up (not in this PR)

Once merged and deployed, the three band-aid Railway env vars (`COREPACK_INTEGRITY_KEYS`, `NIXPACKS_NODE_VERSION`, `NIXPACKS_UV_VERSION`) are removed, since the Dockerfile no longer needs any of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)