### PR TITLE
docs: document the Dockerfile deploy, retire Nixpacks/corepack notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,11 +27,30 @@ mise tasks ls       # all tasks
 
 Notes:
 - **Frontend is on pnpm** (version pinned via `packageManager` and `mise.toml [tools]`); backend
-  is on uv. The Railway buildCommand uses `corepack enable && pnpm install --frozen-lockfile`.
+  is on uv. `mise` is for local dev only.
 - **uv owns the Python venv, not mise** — mise's `python = "3.13"` pin matches `.python-version`,
   but `uv run` reuses an existing `.venv` regardless. `rm -rf .venv && uv sync` rebuilds on 3.13.
 - **No ruff wired here yet**, so `check:api` is pytest-only.
 - **CI gotcha:** never pipe `mise run check` through `tail` — it masks mise's exit code.
+
+## Production build & deploy
+
+Production is built from a committed multi-stage **`Dockerfile`** (not the local mise
+setup, which mise never touches prod). Every tool version is pinned in-repo: Node 22,
+pnpm 10.33.0 (installed directly with `npm i -g`, **not** corepack), Python 3.13,
+uv 0.8.12. `railway.toml` sets `builder = "dockerfile"`; there is no `nixpacks.toml`.
+
+- **Never reintroduce Nixpacks or corepack here.** The prior Nixpacks build silently
+  broke deploys for ~2 months (it defaulted to Node 18, and corepack failed signature
+  verification on a rotated npm key). The Dockerfile exists specifically to make the
+  build explicit and reproducible. Full postmortem: `docs/solutions/deployment-gotchas.md`.
+- **Test build changes locally before pushing:** `docker build -t bc .` then run against
+  a throwaway Postgres (SQLite can't run the Postgres-only migrations). The container's
+  `CMD` runs `alembic upgrade head` then boots uvicorn; the app serves the built SPA from
+  `frontend/dist`.
+- **Runtime config lives in Railway**, not the image: `PORT`, `ENVIRONMENT=production`,
+  `DATABASE_URL`, `R2_*`, `ANTHROPIC_API_KEY`, `REPLICATE_API_TOKEN`, `JWT_SECRET`,
+  `ADMIN_PASSWORD`. Nothing sensitive is baked into the Dockerfile.
 
 ## Development Workflow
 

--- a/docs/solutions/deployment-gotchas.md
+++ b/docs/solutions/deployment-gotchas.md
@@ -1,0 +1,67 @@
+# Deployment gotchas
+
+## Production is built from a committed Dockerfile (2026-07)
+
+Production deploys on Railway build from the repo's multi-stage `Dockerfile`. Every
+tool version is pinned in-repo: Node 22, pnpm 10.33.0, Python 3.13, uv 0.8.12.
+`railway.toml` sets `builder = "dockerfile"`. Runtime config (`PORT`, `ENVIRONMENT`,
+`DATABASE_URL`, secrets) is injected by Railway; nothing sensitive is in the image.
+
+To validate a build change before pushing:
+
+```bash
+docker build -t bc-test .
+# migrations are Postgres-only, so test against Postgres, not SQLite:
+docker network create bc-net
+docker run -d --name bc-pg --network bc-net \
+  -e POSTGRES_PASSWORD=pw -e POSTGRES_USER=bc -e POSTGRES_DB=breadcrumbs postgres:16-alpine
+docker run --rm --network bc-net -p 8199:8199 \
+  -e ENVIRONMENT=production -e PORT=8199 \
+  -e DATABASE_URL="postgresql://bc:pw@bc-pg:5432/breadcrumbs" \
+  -e JWT_SECRET=x -e ADMIN_PASSWORD=x bc-test
+# then: curl localhost:8199/ (SPA), curl localhost:8199/api/themes (JSON)
+```
+
+## Why we do NOT use Nixpacks or corepack (postmortem, 2026-07)
+
+The build used to be Nixpacks with `corepack enable && pnpm install`. It silently
+broke every deploy for ~2 months after the pnpm migration. Two independent causes:
+
+1. **Nixpacks defaulted to Node 18.** Vite 7 needs >= 20.19. Nothing in the repo
+   pinned the Node version (Nixpacks does not read `mise.toml`), so the wrong version
+   was chosen invisibly.
+2. **`corepack enable` failed with "Cannot find matching keyid".** corepack pins npm
+   registry signing keys, npm rotated them, and the bundled corepack (through Node
+   22.11) rejected the pnpm download. The only Nixpacks workaround was
+   `COREPACK_INTEGRITY_KEYS=0`, i.e. disabling signature verification: a band-aid on
+   a security control.
+
+Both are gone with the Dockerfile: Node is pinned to 22, and pnpm is installed
+directly (`npm i -g pnpm@10.33.0`), which never invokes corepack's signing check.
+
+**Rule:** do not reintroduce Nixpacks, corepack, or `COREPACK_INTEGRITY_KEYS` here.
+If pnpm needs bumping, change the pinned version in both `Dockerfile` and
+`frontend/package.json`'s `packageManager` field.
+
+## The build broke silently because deploy failures were invisible
+
+The 2-month gap was not just a broken build; nobody noticed because a failed Railway
+build leaves the previous deployment serving, with no signal in GitHub. Two defenses:
+
+- After merging anything that touches the build, confirm a new deployment actually
+  went live (check the Railway dashboard, or `railway deployment list`).
+- Consider enabling Railway deploy-failure notifications, or a GitHub Actions deploy
+  job, so a failed deploy surfaces where the team already looks.
+
+## `railway up` from an unlinked directory creates a new project
+
+Running `railway up` in a directory with no linked project does not error. It
+silently **creates a new Railway project named after the current folder** and deploys
+there. Always `railway link -p <project> -e <env> -s <service>` first, and confirm the
+build-log URL's project id before trusting a CLI deploy.
+
+## Migrations are Postgres-only
+
+At least one Alembic migration uses Postgres-specific SQL
+(`2026_02_10...merge_theme_title_and_description`). It fails on SQLite with a syntax
+error. Local smoke tests of the full startup path must run against Postgres.


### PR DESCRIPTION
Follows #95 (the Nixpacks → Dockerfile migration).

- Fixes the stale CLAUDE.md note that said the Railway build uses `corepack enable && pnpm install` (it now builds from the Dockerfile).
- Adds `docs/solutions/deployment-gotchas.md`, which CLAUDE.md's Deep-Dive section already linked but which never existed. Captures the 2-month silent-breakage postmortem, the no-Nixpacks/no-corepack rule, the local Postgres build-test recipe, and the `railway up` unlinked-directory footgun.

Docs only; no runtime impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)