### PR TITLE
fix: replace the two-tier Replicate timeout with one generous deadline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,33 +208,31 @@ See `docs/log/README.md` for format and dimensions.
 - Docker builds run `tsc` before `vite build`, so the route tree must be pre-committed
 - If you add a new route file, run `pnpm build` (or `mise run build`) locally and commit the updated `routeTree.gen.ts`
 
-**Replicate theme image generation — two distinct 503 failure modes (`app/images/providers.py`):**
-- Low account credit (<$5) triggers Replicate's own throttle; error text mentions the $5 threshold. Fix: top up billing at replicate.com, not a code change.
-- Timeouts/network errors ("All N candidates failed: timed out...; Network error: The read operation timed out") are a *different* failure — check the Replicate dashboard balance first before assuming it's the credit issue.
+**Replicate theme image generation (`app/images/providers.py`) — the design and why it's simple:**
 
-**NEVER use `replicate.run()` here — it cannot be bounded from outside (`app/images/providers.py`):**
-- `replicate.run()` defaults to `wait=True`, which sets the httpx read timeout to **60.5s** (`replicate/prediction.py::_create_prediction_timeout`). Any wall-clock timeout shorter than that always fires first, making retry logic unreachable dead code.
-- Passing `wait=<int N>` does **not** fix it. When the long-poll expires with the prediction still `starting`, `run()` falls into `prediction.wait()`, a poll loop with **no timeout and no iteration cap**. That is exactly the accept-but-never-start pool failure we need to survive.
-- So we drive `client.predictions.create(..., wait=False)` and poll on our own clock. That is the whole reason this class looks the way it does; do not "simplify" it back to `run()`.
+The two Flux Schnell pools are unreliable in ways that are inherent to serverless GPU, so the whole class exists to survive them without pretending it can make them reliable. It does the minimum that actually works. Do not add "cleverness" back.
 
-**Replicate pools are a failover list, not a constant:**
-- `DEFAULT_FLUX_MODELS` holds canonical `flux-schnell` and the `-lora` sibling. Both have wedged at different times (2026-05: canonical wedged, `-lora` healthy; 2026-07: exactly reversed, measured). A retry moves to the **next pool** — re-rolling the same wedged pool just buys another timeout.
-- Diagnose with a 2-model probe before touching code: create one prediction per model, poll ~45s, see which ever leaves `starting`.
+**NEVER use `replicate.run()` here — it cannot be bounded from outside:**
+- `run()` defaults to `wait=True`, which sets the httpx read timeout to **60.5s** (`replicate/prediction.py::_create_prediction_timeout`). Any wall-clock timeout shorter than that fires first, making retry logic dead code.
+- Passing `wait=<int N>` does **not** fix it: when the long-poll expires with the prediction still `starting`, `run()` falls into `prediction.wait()`, a poll loop with **no timeout and no iteration cap** — exactly the accept-but-never-start failure we must survive.
+- So we drive `client.predictions.create(..., wait=False)` and poll on our own clock (`_await_result`). That is the whole reason this class is not one line; do not "simplify" it back to `run()`.
 
-**Two different timeouts, because "queued forever" and "slow" are different failures:**
-- `REPLICATE_STARTING_TIMEOUT_SECONDS` (15s): still in `starting` means never scheduled onto a GPU. Bail early and fail over.
-- `REPLICATE_ATTEMPT_TIMEOUT_SECONDS` (40s): once `processing` it is genuinely rendering and deserves patience. A healthy cold start measured 25s, so a tighter bound would cancel work about to succeed *and still bill for it*.
-- Abandoned predictions are **cancelled** (`prediction.cancel()`). A read timeout or wedge means the client gave up, not the prediction: it keeps running on GPU and billing until cancelled.
-- The batch backstop is **derived**, never hand-set: `(max_attempts-1)*starting + attempt + max_attempts*http_read`. A backstop below the retry budget silently makes retries unreachable, which was the original bug.
-- The backstop uses a **shared deadline** across candidates, not a fresh timeout per future. They run concurrently, so per-future timeouts let a wedged pool take `num_outputs * timeout` (4 x 60s = 4 min) to surface one error.
+**ONE timeout, not two (learned the hard way, 2026-07):**
+- `REPLICATE_TIMEOUT_SECONDS` (default 45s) is a single per-attempt deadline: a prediction that doesn't reach a terminal state within it is treated as wedged, cancelled, and failed over.
+- An earlier version split `starting` (15s) from `processing` (40s) on the theory that "still `starting`" meant "never scheduled, therefore wedged." **That was wrong and caused a production regression.** Measured reality: healthy Flux Schnell cold starts sit in `starting` for 15-30s before rendering, so the 15s bound cancelled work about to succeed and failed it over to the (then-dead) sibling pool. A single generous deadline separates the cases on its own — a real cold start finishes well under it; a genuinely wedged pool never leaves `starting` and simply hits it. Do not reintroduce a `starting`-specific bound.
 
-**Retry classification — `UNRECOVERABLE_STATUSES` is deliberate:**
-- Retry: wedge, `ModelError`, `httpx.HTTPError`, 5xx, and **404**. 404 is not permanent here: Replicate returned "No adapter found for model" for a model that had succeeded minutes earlier, so it means "this pool is unreachable", which is precisely when to try the next one.
-- Do NOT retry 400/401/402/403/422/429. These are identical on every model, so failover cannot help; it only doubles doomed calls. 402 is the out-of-credit signal that needs a top-up.
+**Two failure modes, two responses (this is the entire control flow):**
+- **Transient `create()` error** (e.g. Replicate's intermittent "No adapter found" 404, or a 5xx/network blip): retry the **same** pool up to `REPLICATE_CREATE_ATTEMPTS` (default 2) before failing over. It's a blip on that pool, not a reason to bounce to a possibly-dead sibling.
+- **Created but never finishes** (wedge, or a `failed`/OOM status): cancel it (`prediction.cancel()`, so it stops billing on the GPU) and **fail over to the next pool**. `DEFAULT_FLUX_MODELS` is a failover list precisely because the two pools wedge at different times (2026-05 canonical wedged / `-lora` healthy; 2026-07 reversed, measured).
+- Unrecoverable create errors (`UNRECOVERABLE_STATUSES` = 400/401/402/403/422/429) are identical on every pool, so neither retry nor failover helps — raise immediately. 402 is the out-of-credit signal (top up at replicate.com); 429 the sub-$5 throttle.
 
-**Env knobs are validated, not raw `int()`:** `_env_number` falls back loudly on malformed or non-positive values. These are module-level constants, so a bare `int("25s")` would crash app startup, and `0` would disable the very bound it configures.
+**Diagnose before touching code:** run a 2-model probe — create one prediction per pool, poll ~45s, see which ever leaves `starting`. A `starting` wedge on both pools at once looks like our 503; check whether it's one pool (failover territory) or an account-level problem (credit/throttle) before assuming a code bug.
 
-**Testing this file:** drive a scripted API through `httpx.MockTransport` (see `FakePool` in `tests/test_images.py`), never a fake that raises instantly. The original bug lived in the SDK's control flow and 49 green tests with instant-raising fakes coexisted with a fix that did nothing in production. Also keep test attempt timeouts short: `ThreadPoolExecutor` cannot cancel running threads and joins them at exit, so a long-running abandoned attempt adds invisible wall clock that pytest's own timings do not show.
+**Batch:** one prediction per candidate (`num_outputs=1`; `-lora` OOMs above 1), fanned out concurrently, sharing one wall-clock `_batch_timeout_seconds` (`len(models) * timeout + slack`). Per-future timeouts would let a wedged pool take `num_outputs * timeout` to surface one error.
+
+**Env knobs are validated, not raw `int()`:** `_env_number` falls back loudly on malformed or non-positive values (these are module-level constants; a bare `int("25s")` would crash startup and `0` would disable the bound).
+
+**Testing this file:** drive a scripted API through `httpx.MockTransport` (see `FakePool` in `tests/test_images.py`), never a fake that raises instantly — the bugs here live in the SDK's control flow. Keep test timeouts short: `ThreadPoolExecutor` cannot cancel running threads and joins them at exit, so a long abandoned attempt adds invisible wall clock.
 
 ## Deep-Dive References
 - **Data model:** `docs/data-model.md`

--- a/app/images/providers.py
+++ b/app/images/providers.py
@@ -19,6 +19,7 @@ import anthropic
 import httpx
 import replicate
 import replicate.exceptions
+import replicate.prediction
 
 from app.images.errors import ImageCommitError, ImageGenerationError
 from app.storage import put_object
@@ -148,85 +149,58 @@ def _env_number(name: str, default: float, cast: Callable[[str], float]) -> floa
     return value
 
 
-# We enforce attempt bounds ourselves rather than delegating to the SDK, because
+# We drive predictions.create(wait=False) and poll on our own clock, because
 # replicate.run() cannot be bounded from outside: once its "Prefer: wait" window
 # expires on a prediction that is still "starting", it falls into prediction.wait(),
-# a poll loop with no timeout and no iteration cap. So we drive
-# predictions.create(wait=False) and poll on our own clock.
+# a poll loop with no timeout and no iteration cap.
 #
-# Two bounds, because "queued forever" and "slow" are different problems:
-#
-# - A prediction still in "starting" has not been scheduled onto a GPU at all. That
-#   is the pool-wedge signature, and no amount of waiting fixes it, so we bail early
-#   and fail over to the other pool.
-# - Once it reaches "processing" it is genuinely rendering, and deserves real
-#   patience. A healthy cold start was measured at 25s, so a bound anywhere near
-#   that would cancel work that was about to succeed (and still bill us for it).
-DEFAULT_STARTING_TIMEOUT_SECONDS = _env_number(
-    "REPLICATE_STARTING_TIMEOUT_SECONDS", 15.0, float
-)
-DEFAULT_ATTEMPT_TIMEOUT_SECONDS = _env_number(
-    "REPLICATE_ATTEMPT_TIMEOUT_SECONDS", 40.0, float
-)
-DEFAULT_MAX_ATTEMPTS = int(_env_number("REPLICATE_MAX_ATTEMPTS", 2, lambda v: int(v)))
+# ONE deadline, not two. An earlier version split "starting" (15s) from "processing"
+# (40s) on the theory that a prediction still in "starting" had never been scheduled
+# and was therefore wedged. Measurement disproved it: healthy Flux Schnell cold starts
+# routinely sit in "starting" for 15-30s before they render, so the 15s bound cancelled
+# work that was about to succeed and failed over to the sibling pool for no reason. A
+# single generous deadline separates the cases cleanly — a real cold start finishes
+# well under it; a genuinely wedged pool never leaves "starting" and simply hits it.
+DEFAULT_TIMEOUT_SECONDS = _env_number("REPLICATE_TIMEOUT_SECONDS", 45.0, float)
 
-# Caps how long any single HTTP call (create, poll, cancel) may block. The SDK's
-# default read timeout is 30s, which is far longer than a poll needs and would let
-# one wedged reload blow the attempt budget.
-DEFAULT_HTTP_READ_TIMEOUT_SECONDS = _env_number(
-    "REPLICATE_HTTP_READ_TIMEOUT_SECONDS", 10.0, float
-)
+# A create() call can fail transiently on one pool: Replicate has returned
+# "No adapter found" 404s for a model that succeeded moments earlier. That is a blip on
+# this pool, not a reason to abandon it for a possibly-dead sibling, so we re-create on
+# the same pool up to this many times before failing over.
+DEFAULT_CREATE_ATTEMPTS = int(_env_number("REPLICATE_CREATE_ATTEMPTS", 2, int))
 
 
 class PredictionWedged(Exception):
-    """A prediction never reached a terminal state within its attempt budget."""
+    """A prediction never reached a terminal state within its deadline."""
 
 
-# Account- or request-level failures: identical on every model, so failing over
-# cannot help and only doubles the doomed calls. 402 in particular is Replicate's
-# out-of-credit signal, which needs a top-up rather than another request.
-#
-# Everything else, including 404, is treated as model- or infrastructure-level and
-# is worth trying on the next pool. 404 earns its place here empirically: Replicate
-# returned "No adapter found for model" for a model that had succeeded minutes
-# earlier, so it is not the permanent "no such model" a 404 usually implies.
+# Account- or request-level create failures: the same on every pool, so retrying or
+# failing over only doubles doomed calls. 402 is Replicate's out-of-credit signal (top
+# up, don't retry), 401 a bad token, 400/422 a bad request, 429 a rate limit. Anything
+# else — including 404 and 5xx — is transient or infra-level and worth another try.
 UNRECOVERABLE_STATUSES = frozenset({400, 401, 402, 403, 422, 429})
 
 
-def _is_retryable(error: BaseException) -> bool:
-    """Is this worth spending another attempt (on the next model) on?"""
-    if isinstance(error, PredictionWedged):
-        return True
-    if isinstance(error, replicate.exceptions.ModelError):
-        return True  # CUDA OOM and friends; a re-roll usually lands somewhere healthy
-    if isinstance(error, replicate.exceptions.ReplicateError):
-        status = getattr(error, "status", None)
-        if not isinstance(status, int):
-            return False
-        return status not in UNRECOVERABLE_STATUSES
-    if isinstance(error, httpx.HTTPError):
-        return True  # read timeout, connection reset: transport-level, not semantic
-    return False
+def _is_unrecoverable(error: replicate.exceptions.ReplicateError) -> bool:
+    """A create error that retrying or failing over cannot fix."""
+    status = getattr(error, "status", None)
+    return isinstance(status, int) and status in UNRECOVERABLE_STATUSES
 
 
 class ReplicateImageGenerator:
-    """Generates candidates via parallel Flux Schnell predictions.
+    """Generates candidate images via parallel Flux Schnell predictions.
 
-    Each candidate is its own prediction with ``num_outputs=1``, so a single CUDA OOM
-    or stuck worker costs one candidate rather than the whole batch.
+    Each candidate is its own prediction with ``num_outputs=1``, run concurrently, so
+    one stuck or failed prediction costs a single candidate rather than the whole batch.
+    ``generate`` returns every candidate that succeeded; the caller lets the user pick.
 
-    Time is bounded at three levels, and the ordering is the invariant:
+    Robustness is two simple rules, one per failure mode Replicate actually exhibits:
 
-    1. ``starting_timeout_seconds`` catches a pool that accepted the prediction but
-       never scheduled it. On expiry we cancel and fail over to the next model.
-    2. ``attempt_timeout_seconds`` bounds an attempt that *is* rendering. We create
-       non-blocking and poll ourselves, so this is a real bound rather than a
-       request we hope the SDK honors. On expiry the prediction is cancelled;
-       otherwise it keeps running on GPU and billing.
-    3. ``timeout_seconds`` is a batch-wide wall-clock backstop, derived from (2) and
-       ``max_attempts`` so it cannot be configured below the retry budget. It is a
-       last resort: Python cannot cancel a running thread, so if a worker thread
-       wedges anyway this is what lets the request return.
+    - A ``create`` that fails transiently (e.g. a "No adapter found" 404) is retried on
+      the *same* pool a few times before moving on — the pool is flaking, not down.
+    - A prediction that is created but never finishes within ``timeout_seconds`` means
+      the pool is wedged: we cancel it (so it stops billing) and fail over to the next
+      pool.
     """
 
     def __init__(
@@ -234,37 +208,22 @@ class ReplicateImageGenerator:
         models: Sequence[str] = DEFAULT_FLUX_MODELS,
         aspect_ratio: str = "1:1",
         num_outputs: int = 4,
-        timeout_seconds: Optional[float] = None,
-        starting_timeout_seconds: float = DEFAULT_STARTING_TIMEOUT_SECONDS,
-        attempt_timeout_seconds: float = DEFAULT_ATTEMPT_TIMEOUT_SECONDS,
-        max_attempts: int = DEFAULT_MAX_ATTEMPTS,
-        http_read_timeout_seconds: float = DEFAULT_HTTP_READ_TIMEOUT_SECONDS,
+        timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+        create_attempts: int = DEFAULT_CREATE_ATTEMPTS,
         client: Optional[replicate.Client] = None,
     ) -> None:
         if not models:
             raise ValueError("models must not be empty")
         self._models = tuple(models)
-        self._starting_timeout_seconds = starting_timeout_seconds
         self._aspect_ratio = aspect_ratio
         self._num_outputs = num_outputs
-        self._attempt_timeout_seconds = attempt_timeout_seconds
-        self._max_attempts = max_attempts
-        self._http_read_timeout_seconds = http_read_timeout_seconds
+        self._timeout_seconds = timeout_seconds
+        self._create_attempts = create_attempts
         self._client = client
-        # Worst realistic path: every attempt but the last gives up early as wedged,
-        # and the last one runs its full budget. Each attempt can also overrun by at
-        # most one in-flight HTTP call. Derived rather than hand-set, because a
-        # backstop shorter than the retry budget silently makes retries unreachable,
-        # which is the bug this class was rewritten to fix.
-        self._timeout_seconds = (
-            timeout_seconds
-            if timeout_seconds is not None
-            else (
-                (max_attempts - 1) * starting_timeout_seconds
-                + attempt_timeout_seconds
-                + max_attempts * http_read_timeout_seconds
-            )
-        )
+        # Batch safety net: a candidate tries every pool once, each bounded by
+        # timeout_seconds, so its worst case is len(models) * timeout. Candidates run
+        # concurrently, so the batch shares one deadline rather than summing theirs.
+        self._batch_timeout_seconds = len(self._models) * timeout_seconds + 15.0
 
     def generate(self, prompt: str) -> List[str]:
         client = self._get_client()
@@ -280,8 +239,8 @@ class ReplicateImageGenerator:
             # One deadline shared across all candidates. They were all submitted at
             # once and run concurrently, so the budget is batch-wide: giving each
             # future its own fresh timeout would let a fully-wedged pool take
-            # num_outputs * timeout (4 * 60s = 4 minutes) to surface one error.
-            deadline = time.monotonic() + self._timeout_seconds
+            # num_outputs * timeout to surface one error.
+            deadline = time.monotonic() + self._batch_timeout_seconds
             for future in futures:
                 remaining = max(0.0, deadline - time.monotonic())
                 try:
@@ -316,81 +275,99 @@ class ReplicateImageGenerator:
         token = os.getenv("REPLICATE_API_TOKEN")
         if not token:
             raise ImageGenerationError("REPLICATE_API_TOKEN is not set")
+        # Cap any single HTTP call (create, poll, cancel) so one wedged request can't
+        # blow the deadline. The SDK's 30s default read timeout is far longer than a
+        # poll needs.
         self._client = replicate.Client(
             api_token=token,
-            timeout=httpx.Timeout(
-                5.0,
-                connect=5.0,
-                read=self._http_read_timeout_seconds,
-                write=self._http_read_timeout_seconds,
-                pool=10.0,
-            ),
+            timeout=httpx.Timeout(5.0, connect=5.0, read=10.0, write=10.0, pool=10.0),
         )
         return self._client
 
     def _generate_one(self, client: replicate.Client, prompt: str) -> str:
-        last_error: Optional[BaseException] = None
-        for attempt in range(1, self._max_attempts + 1):
-            # Move to the next pool on each retry. When a pool wedges it stops
-            # scheduling *everything*, so re-rolling against the same one just buys
-            # another timeout; the other pool is usually healthy at that moment.
-            model = self._models[(attempt - 1) % len(self._models)]
+        # Try each pool in order. Every failure is recorded so the caller can report
+        # what actually happened on *both* pools, not just the last one.
+        errors: List[str] = []
+        for model in self._models:
+            prediction = self._create(client, prompt, model, errors)
+            if prediction is None:
+                continue  # create kept failing transiently on this pool; fail over
             try:
-                return self._run_attempt(client, prompt, model)
+                return self._await_result(client, prediction)
             except (
                 PredictionWedged,
                 replicate.exceptions.ReplicateException,
                 httpx.HTTPError,
             ) as e:
-                if not _is_retryable(e):
-                    raise ImageGenerationError(f"Replicate error: {e}") from e
-                last_error = e
+                # Wedged, model error (CUDA OOM), or a poll blip: this pool isn't
+                # delivering, so fail over to the next one.
+                errors.append(f"{model}: {e}")
                 logger.warning(
-                    "Replicate attempt %d/%d on %s failed (%s): %s",
-                    attempt, self._max_attempts, model, type(e).__name__, e,
+                    "Replicate on %s failed (%s): %s", model, type(e).__name__, e
                 )
+        raise ImageGenerationError("; ".join(errors) or "no pools available")
 
-        raise ImageGenerationError(
-            f"Failed after {self._max_attempts} attempts: {last_error}"
-        ) from last_error
+    def _create(
+        self,
+        client: replicate.Client,
+        prompt: str,
+        model: str,
+        errors: List[str],
+    ) -> Optional["replicate.prediction.Prediction"]:
+        """Create a prediction, retrying transient failures on the same pool.
 
-    def _run_attempt(self, client: replicate.Client, prompt: str, model: str) -> str:
-        prediction = client.predictions.create(
-            model=model,
-            input={
-                "prompt": prompt,
-                "num_outputs": 1,
-                "aspect_ratio": self._aspect_ratio,
-                "output_format": "webp",
-                "output_quality": 90,
-            },
-            wait=False,
-        )
+        Returns the prediction, or ``None`` if this pool should be failed over.
+        Re-raises as ImageGenerationError for unrecoverable errors (bad token, out of
+        credit) — those are the same on every pool, so there is nothing to fail over to.
+        """
+        for attempt in range(1, self._create_attempts + 1):
+            try:
+                return client.predictions.create(
+                    model=model,
+                    input={
+                        "prompt": prompt,
+                        "num_outputs": 1,
+                        "aspect_ratio": self._aspect_ratio,
+                        "output_format": "webp",
+                        "output_quality": 90,
+                    },
+                    wait=False,
+                )
+            except replicate.exceptions.ReplicateError as e:
+                if _is_unrecoverable(e):
+                    raise ImageGenerationError(f"Replicate error: {e}") from e
+                errors.append(f"{model} create failed (attempt {attempt}): {e}")
+                logger.warning(
+                    "Replicate create on %s failed (attempt %d/%d): %s",
+                    model, attempt, self._create_attempts, e,
+                )
+            except httpx.HTTPError as e:
+                errors.append(f"{model} create network error (attempt {attempt}): {e}")
+                logger.warning(
+                    "Replicate create on %s network error (attempt %d/%d): %s",
+                    model, attempt, self._create_attempts, e,
+                )
+        return None
 
-        started = time.monotonic()
-        scheduling_deadline = started + self._starting_timeout_seconds
-        attempt_deadline = started + self._attempt_timeout_seconds
+    def _await_result(
+        self,
+        client: replicate.Client,
+        prediction: "replicate.prediction.Prediction",
+    ) -> str:
+        deadline = time.monotonic() + self._timeout_seconds
         while prediction.status not in TERMINAL_STATUSES:
-            now = time.monotonic()
-            # Read the status before cancelling; cancel() overwrites it.
-            stuck_at = prediction.status
-            if stuck_at == "starting" and now >= scheduling_deadline:
+            if time.monotonic() >= deadline:
+                stuck_at = prediction.status  # read before cancel() overwrites it
                 self._abandon(prediction)
                 raise PredictionWedged(
-                    f"{model} never left 'starting' within "
-                    f"{self._starting_timeout_seconds:.0f}s"
-                )
-            if now >= attempt_deadline:
-                self._abandon(prediction)
-                raise PredictionWedged(
-                    f"{model} still {stuck_at} after "
-                    f"{self._attempt_timeout_seconds:.0f}s"
+                    f"did not finish within {self._timeout_seconds:.0f}s "
+                    f"(stuck at '{stuck_at}')"
                 )
             time.sleep(client.poll_interval)
             prediction.reload()
 
         if prediction.status == "failed":
-            # Matches replicate.run()'s own handling; ModelError is retryable.
+            # Matches replicate.run()'s own handling; ModelError fails us over.
             raise replicate.exceptions.ModelError(prediction)
         if prediction.status == "canceled":
             raise ImageGenerationError("Prediction was canceled")

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -447,17 +447,16 @@ def _generator(pool: "FakePool", **kwargs) -> ReplicateImageGenerator:
     )
     client.poll_interval = 0.01
     kwargs.setdefault("num_outputs", 1)
-    kwargs.setdefault("starting_timeout_seconds", 0.2)
-    kwargs.setdefault("attempt_timeout_seconds", 0.4)
-    kwargs.setdefault("http_read_timeout_seconds", 0.3)
+    kwargs.setdefault("timeout_seconds", 0.3)
     return ReplicateImageGenerator(client=client, **kwargs)
 
 
 SUCCESS = {"statuses": ["succeeded"], "output": ["https://r/ok.webp"]}
 WEDGED = {"statuses": ["starting"]}  # never leaves "starting" — the real failure mode
-# Reaches a GPU and renders, just not instantly. Must NOT be killed as wedged.
-SLOW_BUT_ALIVE = {
-    "statuses": ["starting", "processing", "processing", "processing", "succeeded"],
+# Sits in "starting" for several polls before it renders. The old two-tier design
+# killed this at the 15s "starting" bound; one generous deadline must let it finish.
+SLOW_TO_SCHEDULE = {
+    "statuses": ["starting", "starting", "starting", "processing", "succeeded"],
     "output": ["https://r/slow.webp"],
 }
 
@@ -469,28 +468,28 @@ def test_replicate_generator_missing_token(monkeypatch):
         generator.generate("prompt")
 
 
-def test_wedged_prediction_is_cancelled_and_retried():
+def test_wedged_prediction_is_cancelled_and_failed_over():
     """THE regression test.
 
     A pool that accepts predictions but never starts them is the documented failure
-    mode. Previously replicate.run() would block in an unbounded poll loop here, so
-    the retry never fired and the abandoned prediction kept billing. Now: two
-    creates (the retry ran) and two cancels (neither orphan was left running).
+    mode. replicate.run() would block here in an unbounded poll loop; we bound it,
+    cancel the abandoned prediction so it stops billing, and fail over to the other
+    pool. Both default pools wedge here: two creates, two cancels, one clean error.
     """
     pool = FakePool(WEDGED, WEDGED)
-    generator = _generator(pool, max_attempts=2)
+    generator = _generator(pool)
 
     with pytest.raises(ImageGenerationError, match="All 1 candidates failed"):
         generator.generate("prompt")
 
-    assert pool.creates == 2, "retry did not fire against a wedged pool"
+    assert pool.creates == 2, "did not fail over to the second pool"
     assert len(pool.cancels) == 2, "abandoned predictions were left billing"
 
 
-def test_wedged_first_attempt_then_healthy_worker_succeeds():
-    """The whole point of retrying: re-roll off a stuck worker onto a good one."""
+def test_wedged_first_pool_then_healthy_second_pool_succeeds():
+    """Failover's whole point: a wedged pool must not sink the candidate."""
     pool = FakePool(WEDGED, SUCCESS)
-    generator = _generator(pool, max_attempts=2)
+    generator = _generator(pool)
 
     assert generator.generate("prompt") == ["https://r/ok.webp"]
     assert pool.creates == 2
@@ -498,90 +497,74 @@ def test_wedged_first_attempt_then_healthy_worker_succeeds():
 
 
 def test_wedged_pool_fails_over_to_the_next_model():
-    """A wedged pool stops scheduling everything, so retrying it is pointless.
+    """A wedged pool stops scheduling everything, so the retry must change pools.
 
-    Observed 2026-07-21: flux-schnell-lora stuck in "starting" past 45s while the
-    canonical pool succeeded in 25s. In 2026-05 the positions were reversed. The
-    retry must change pools, not just re-roll.
+    Observed 2026-07: flux-schnell-lora stuck in "starting" past 45s while the
+    canonical pool succeeded in seconds. Failover moves to the next pool; it does not
+    re-roll the wedged one.
     """
     pool = FakePool(WEDGED, SUCCESS)
-    generator = _generator(
-        pool,
-        models=["pool-a/model", "pool-b/model"],
-        max_attempts=2,
-    )
+    generator = _generator(pool, models=["pool-a/model", "pool-b/model"])
 
     assert generator.generate("prompt") == ["https://r/ok.webp"]
     assert pool.models == ["pool-a/model", "pool-b/model"], "retry reused the bad pool"
 
 
-def test_slow_but_processing_prediction_is_not_killed_as_wedged():
-    """"Queued forever" and "slow" are different failures.
-
-    A healthy cold start was measured at 25s. Treating that as wedged would cancel
-    work about to succeed, and still bill for it.
-    """
-    pool = FakePool(SLOW_BUT_ALIVE)
-    generator = _generator(
-        pool,
-        starting_timeout_seconds=0.05,  # would fire immediately if status were ignored
-        attempt_timeout_seconds=5.0,
-        max_attempts=1,
-    )
+def test_slow_to_schedule_prediction_is_not_killed():
+    """The regression #94 introduced: a healthy cold start sits in "starting" for
+    15-30s. The old 15s "starting" bound cancelled it and failed over for no reason;
+    one generous deadline lets it finish. Here it stays "starting" for three polls
+    before it renders."""
+    pool = FakePool(SLOW_TO_SCHEDULE)
+    generator = _generator(pool, timeout_seconds=5.0)
 
     assert generator.generate("prompt") == ["https://r/slow.webp"]
-    assert pool.cancels == [], "cancelled a prediction that was actively processing"
-
-
-def test_wedged_batch_stays_within_the_wall_clock_backstop():
-    pool = FakePool(WEDGED)
-    generator = _generator(
-        pool, num_outputs=4, max_attempts=2, attempt_timeout_seconds=0.2
-    )
-    started = time.monotonic()
-    with pytest.raises(ImageGenerationError):
-        generator.generate("prompt")
-    elapsed = time.monotonic() - started
-    assert elapsed < generator._timeout_seconds + 1.0
+    assert pool.cancels == [], "cancelled a prediction that was still scheduling"
 
 
 @pytest.mark.parametrize("status", [400, 401, 402, 403, 422, 429])
-def test_account_level_errors_are_not_retried(status):
-    """Retrying a bad token, exhausted credit, or bad input cannot succeed.
-
-    These are identical on every model, so failing over cannot help. It only
-    doubles the doomed calls (4 candidates x 2 attempts = 8) and doubles
-    time-to-error. 429 is included deliberately: Replicate's documented throttle
-    below $5 credit needs a top-up, not another request.
-    """
+def test_account_level_create_errors_are_not_retried_or_failed_over(status):
+    """A bad token, exhausted credit, bad input, or rate limit is identical on every
+    pool, so retrying the same pool or failing over only doubles doomed calls. 402 is
+    the out-of-credit signal (top up); 429 the documented sub-$5 throttle."""
     pool = FakePool(status)
-    generator = _generator(pool, max_attempts=2)
+    generator = _generator(pool)
 
     with pytest.raises(ImageGenerationError):
         generator.generate("prompt")
 
-    assert pool.creates == 1, f"HTTP {status} should not be retried"
+    assert pool.creates == 1, f"HTTP {status} should not be retried or failed over"
 
 
 @pytest.mark.parametrize("status", [404, 500, 502, 503])
-def test_model_and_infrastructure_errors_fail_over(status):
-    """404 belongs here, not with the permanent errors.
-
-    Observed live 2026-07-21: Replicate returned "No adapter found for model" for a
-    model that had succeeded minutes earlier. In a failover list a 404 means "this
-    pool is unreachable", which is precisely when the next one should be tried.
-    """
+def test_transient_create_error_retries_the_same_pool(status):
+    """The flux-schnell fix. Replicate returns transient "No adapter found" 404s (and
+    5xx) for a pool that works moments later. That is a blip on THIS pool, so we
+    re-create on the same pool rather than bouncing to a possibly-dead sibling."""
     pool = FakePool(status, SUCCESS)
-    generator = _generator(pool, max_attempts=2)
+    generator = _generator(pool, models=["pool-a/model", "pool-b/model"])
 
     assert generator.generate("prompt") == ["https://r/ok.webp"]
     assert pool.creates == 2
+    assert pool.models == ["pool-a/model", "pool-a/model"], "did not retry same pool"
 
 
-def test_failed_prediction_is_retried_on_a_new_worker():
-    """A "failed" status is the CUDA-OOM shape; a re-roll usually lands healthy."""
+def test_create_errors_fail_over_after_exhausting_the_same_pool():
+    """Once a pool's create attempts are spent, move on: pool-a 404s both attempts,
+    then pool-b succeeds."""
+    pool = FakePool(404, 404, SUCCESS)
+    generator = _generator(
+        pool, models=["pool-a/model", "pool-b/model"], create_attempts=2
+    )
+
+    assert generator.generate("prompt") == ["https://r/ok.webp"]
+    assert pool.models == ["pool-a/model", "pool-a/model", "pool-b/model"]
+
+
+def test_failed_prediction_fails_over_to_the_next_pool():
+    """A "failed" status is the CUDA-OOM shape; failing over usually lands healthy."""
     pool = FakePool({"statuses": ["failed"]}, SUCCESS)
-    generator = _generator(pool, max_attempts=2)
+    generator = _generator(pool)
 
     assert generator.generate("prompt") == ["https://r/ok.webp"]
     assert pool.creates == 2
@@ -591,7 +574,7 @@ def test_succeeded_with_null_output_is_a_clean_error_not_a_crash():
     """Guards a 500. A prediction can report success with output=None; list(None)
     would raise TypeError, which api.py does not catch."""
     pool = FakePool({"statuses": ["succeeded"], "output": None})
-    generator = _generator(pool, max_attempts=1)
+    generator = _generator(pool)
 
     with pytest.raises(ImageGenerationError, match="no output"):
         generator.generate("prompt")
@@ -625,7 +608,7 @@ def test_generator_sends_correct_input_shape_and_does_not_block_on_create():
 def test_generator_returns_partial_results_when_some_candidates_fail():
     """Degraded beats dead: one bad candidate must not fail the whole batch."""
     pool = FakePool(SUCCESS, 422, SUCCESS, SUCCESS)
-    generator = _generator(pool, num_outputs=4, max_attempts=1)
+    generator = _generator(pool, num_outputs=4)
 
     assert len(generator.generate("prompt")) == 3
 
@@ -637,44 +620,25 @@ def test_generator_handles_fileoutput_style_objects():
     assert ReplicateImageGenerator._extract_url([_FileOutput()]) == "https://r/from-object.webp"
 
 
-def test_batch_timeout_is_shared_not_per_candidate():
-    """Candidates run concurrently, so the budget is batch-wide. Per-future
-    timeouts would let a wedged pool burn num_outputs * timeout.
-
-    max_attempts=1 and a modest attempt timeout keep the abandoned worker threads
-    short-lived: they cannot be cancelled, and ThreadPoolExecutor joins them at
-    interpreter exit, so an over-long attempt here would add invisible wall clock
-    to every CI run without showing up in pytest's own timings.
-    """
+def test_wedged_batch_returns_concurrently_not_summed():
+    """Candidates run in parallel and share one deadline. Four wedged candidates,
+    each trying two pools, must surface in roughly one candidate's time, not four."""
     pool = FakePool(WEDGED)
-    generator = _generator(
-        pool,
-        num_outputs=4,
-        timeout_seconds=0.3,
-        attempt_timeout_seconds=1.5,
-        max_attempts=1,
-    )
+    generator = _generator(pool, num_outputs=4, timeout_seconds=0.2)
+
     started = time.monotonic()
     with pytest.raises(ImageGenerationError, match="All 4 candidates failed"):
         generator.generate("prompt")
     elapsed = time.monotonic() - started
-    assert elapsed < 2.0, f"batch took {elapsed:.1f}s — timeout is not shared"
+
+    assert elapsed < 2.0, f"batch took {elapsed:.1f}s — candidates were not concurrent"
 
 
-def test_backstop_is_derived_to_fit_the_full_retry_budget():
-    """Worst realistic path: N-1 attempts bail early as wedged, the last runs full."""
-    generator = ReplicateImageGenerator(
-        starting_timeout_seconds=15,
-        attempt_timeout_seconds=40,
-        http_read_timeout_seconds=10,
-        max_attempts=2,
-    )
-    assert generator._timeout_seconds == 15 + 40 + 20
-
-
-def test_explicit_timeout_overrides_the_derived_backstop():
-    generator = ReplicateImageGenerator(timeout_seconds=3.0, max_attempts=2)
-    assert generator._timeout_seconds == 3.0
+def test_batch_timeout_scales_with_pools_and_per_attempt_timeout():
+    """A candidate tries each pool once, so the batch backstop is len(models) *
+    timeout (plus HTTP slack), never below the per-candidate budget."""
+    generator = ReplicateImageGenerator(models=["a/m", "b/m"], timeout_seconds=10.0)
+    assert generator._batch_timeout_seconds == 2 * 10.0 + 15.0
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What was broken

Theme cover generation was 503ing with `flux-schnell-lora never left 'starting' within 15s` on every candidate, repeatedly.

## Root cause

Two things stacked, and the second is ours:

1. Replicate's public Flux Schnell pools are intermittently unreliable (cold-start scheduling, wedged pools, transient `No adapter found` 404s).
2. **PR #94's 15s "starting" timeout was the regression.** It declared any prediction still in `starting` after 15s "wedged" and failed it over. But measured cold starts sit in `starting` for **15-30s** before rendering, so the bound cancelled work that was about to succeed and bounced it to the sibling `-lora` pool — which happened to be dead. Net: both attempts fail, every candidate 503s.

Diagnosis was confirmed by direct probing of both pools and by production logs (which showed attempt-1 on `flux-schnell` also being killed at 15s — the UI only ever reported the last attempt, `-lora`).

## The fix (simplify, don't tune)

- **One per-attempt deadline** (`REPLICATE_TIMEOUT_SECONDS`, 45s) instead of the `starting`/`processing` two-tier split. A real cold start finishes under it; a genuinely wedged pool never leaves `starting` and just hits it.
- **Transient create errors retry the same pool** (`REPLICATE_CREATE_ATTEMPTS`, 2) before failing over, so a `No adapter found` blip doesn't bounce to a possibly-dead sibling.
- **Errors accumulate per pool**, so the message reports what happened on *both* pools, not just the last attempt.

Deletes the derived-backstop math, the two-tier knobs, and the `_is_retryable` status table (~net simpler). Preserves the hard-won invariants: never `replicate.run()` (unbounded poll), cancel abandoned predictions so they stop billing, and the pool failover list. **The click-to-generate-and-pick UX is unchanged.**

## Testing

- Rewrote the `ReplicateImageGenerator` test suite against the scripted `httpx.MockTransport` harness to cover: single-deadline behavior, slow-to-schedule predictions surviving, same-pool create retry, failover after exhausting a pool, cancel-on-wedge, account-level errors not retried, concurrent batch.
- `mise run check` green (239 backend tests, eslint, tsc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)