### PR TITLE
docs: commit the three deep-dive references CLAUDE.md points at

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -1,0 +1,40 @@
+# Data Model
+
+## Theme
+- `id` - Primary key
+- `body_md` - Required markdown content (the thought itself, e.g., "The past and future are ghosts...")
+- `visibility` - Enum: draft or published (controls reader visibility)
+- `created_at` - When theme was created
+- `updated_at` - Last modified datetime
+- `breadcrumbs` - Relationship to breadcrumbs (one-to-many)
+- `tags` - Relationship to tags (many-to-many via ThemeTag)
+- **Purpose:** A thought that can have sub-thoughts (breadcrumbs). Themes are the primary organizational unit. Tags and visibility are managed at theme level.
+
+## Breadcrumb
+- `id` - Primary key
+- `body_md` - Markdown text (the actual thought/content atom)
+- `created_at` - Created datetime
+- `updated_at` - Last modified datetime
+- `theme_id` - Foreign key to Theme (required, one-to-many)
+- `parent_id` - Optional FK to another Breadcrumb (self-referential, adjacency list pattern)
+- **Purpose:** Small individual thought atoms that belong to a theme. Breadcrumbs can nest: a breadcrumb with `parent_id` is a reply/elaboration on another breadcrumb. `parent_id` is immutable after creation. Visibility is inherited from parent theme.
+
+## Tag
+- `id` - Primary key
+- `name` - Tag name (normalized: lowercase, dashes, unique)
+- `position` - Optional int for writer-defined custom ordering (nullable; set via `PATCH /api/tags/reorder`)
+- `themes` - Relationship to themes (many-to-many via ThemeTag)
+
+## ThemeTag (join table)
+- `theme_id` - Foreign key to Theme
+- `tag_id` - Foreign key to Tag
+
+## Relationship Design
+- **Themes = Thoughts**: Primary content units with body, tags, and visibility
+- **Breadcrumbs = Sub-thoughts**: Individual thought atoms that belong to exactly one theme
+- **Breadcrumb nesting**: Breadcrumbs can have parent-child relationships (adjacency list). Parent must be in the same theme. Cascade delete: deleting a parent deletes all children. Depth soft-limited to 10 at the API level.
+- **Tags = Discovery mechanism**: Applied to themes for filtering and browsing
+- Themes must have body_md and can have 0+ tags
+- Breadcrumbs must belong to exactly one theme
+- Only published themes (and their breadcrumbs) are visible to readers
+- Writers see both draft and published themes when authenticated

--- a/docs/digests.md
+++ b/docs/digests.md
@@ -1,0 +1,64 @@
+# Digests (Weekly & Monthly Summaries)
+
+**What:** AI-generated summaries that appear inline in the main feed, interleaved chronologically with regular breadcrumbs. Weekly summaries (2-4 sentences) recap the week's themes. Monthly summaries (3-6 sentences) synthesize weekly summaries into higher-altitude arcs via progressive summarization.
+
+## Architecture
+- `app/digest/` -- Generation (Claude), email (Resend), sending, API routes
+- Models: `Digest`, `DigestType`, `Subscriber`, `DigestSend` (in `app/models.py`)
+- `DigestType` enum: `weekly` or `monthly` -- stored on the `Digest` model
+- Frontend: summaries render inline via `WeeklySummary` component in the main feed
+- Writer dashboard: digests interleaved chronologically with themes, clickable detail page at `/writer/digests/$digestId`
+- Confirm/unsubscribe pages: `/digest/confirm`, `/digest/unsubscribe`
+- Scheduler: `app/scheduler.py` -- APScheduler `BackgroundScheduler` with three cron jobs
+- AI indicator: subtle sparkles icon (lucide-react) in bottom-right of every summary card, with "AI-generated summary" tooltip
+
+## How summaries appear in the feed
+- The feed merges date-grouped themes and published digests into one chronological list
+- Summaries are keyed by `period_end` date, so they appear after that period's content
+- Different visual treatment: dashed border, muted background, lighter heading
+- Monthly headings show "February 2026", weekly show "Week of Feb 1-7, 2026"
+- Summaries are hidden when tag/search filters are active
+
+## Progressive summarization
+- Weekly digests summarize raw themes + breadcrumbs
+- Monthly digests summarize published weekly digests (not raw content)
+- Fallback: if no weekly digests exist for a month, falls back to raw content
+- This creates a pyramid of abstraction: weekly captures details, monthly captures trends
+- Future: yearly summaries from monthly summaries
+
+## Admin workflow (manual or agent)
+1. `POST /api/digests/generate?period_start=YYYY-MM-DD&period_end=YYYY-MM-DD&digest_type=weekly` -- Claude writes a summary (draft)
+2. `POST /api/digests/generate?digest_type=monthly` -- generates monthly from weekly summaries (auto-detects previous month bounds)
+3. `POST /api/digests/{id}/publish` -- Makes it visible in the feed
+4. `POST /api/digests/{id}/send` -- (Optional) deliver to email subscribers
+
+## Scheduler (APScheduler)
+- In-process `BackgroundScheduler` in `app/scheduler.py`, gated behind `ENABLE_SCHEDULER=true`
+- Sunday 6am PT (14:00 UTC): generates a draft weekly digest for the past week
+- 1st of month 6am PT (14:00 UTC): generates a draft monthly digest for the previous month
+- Tuesday 6am PT (14:00 UTC): publishes and sends any draft digests (weekly or monthly)
+- Idempotent: checks for existing digest with same `period_start` + `digest_type` before generating
+- Each job creates its own `Session(engine)` since it runs outside request context
+- **Known limitation:** generating early in the week/month then generating again later does NOT update the draft -- it skips because one already exists. Regeneration not yet implemented.
+
+## Legacy cron endpoint (still available)
+`POST /api/internal/weekly-digest?secret=X&auto_send=true`
+- Needs `CRON_SECRET` env var set
+- Superseded by APScheduler but kept for manual triggering
+
+## Email subscriptions (modular, can be removed)
+- Subscribe widget at bottom of feed with double opt-in flow
+- Resend for delivery (RESEND_API_KEY env var)
+- Emails contain the short summary + link to homepage
+- Subscriber flow is fully independent of summary display
+
+## Key constraints
+- `UNIQUE(period_start, digest_type)` on digest -- prevents duplicate digests per period and type
+- `UNIQUE(digest_id, subscriber_id)` on digest_send -- prevents double-sending
+- Indexes on `confirmation_token` and `unsubscribe_token` for fast lookups
+
+## Generation prompts
+Live in `app/digest/generate.py`. Weekly: `SYSTEM_PROMPT` (journalist capsule recap). Monthly: `MONTHLY_SYSTEM_PROMPT` (magazine month-in-review). Both third-person, warm, observational.
+
+## Future direction
+Yearly summaries from monthly summaries. Digest regeneration for updating drafts.

--- a/docs/solutions/cascade-patterns.md
+++ b/docs/solutions/cascade-patterns.md
@@ -1,0 +1,47 @@
+# Cascade Delete Patterns (SQLModel + SQLAlchemy)
+
+## Hybrid Approach
+Use three together for proper cascade delete behavior:
+1. **Database level:** `ondelete="CASCADE"` in `Field()` - enforces at SQL level
+2. **ORM awareness:** `cascade="all, delete[-orphan]"` in relationship - tells SQLAlchemy what's happening
+3. **Efficiency:** `passive_deletes=True` - uses DB cascade for unloaded collections
+
+## When to use `delete-orphan`
+- Existential dependency (child can't exist without parent)
+- Example: Breadcrumb -> Theme (breadcrumb without theme is invalid)
+- Example: Breadcrumb -> Parent Breadcrumb (self-referential, reply without parent is orphaned)
+- Deletes children when removed from collection OR parent deleted
+
+## When to use `save-update, merge` only (many-to-many)
+- Independent entities linked by a join table
+- Example: Theme <-> Tag (both exist independently)
+- DB-level `ondelete="CASCADE"` on the join table FKs handles link row cleanup
+- Do NOT use `cascade="all, delete"` -- this deletes the *related entities*, not just the association rows
+
+## Example
+
+```python
+# One-to-many with orphan deletion (Theme -> Breadcrumbs)
+breadcrumbs: List["Breadcrumb"] = Relationship(
+    back_populates="theme",
+    sa_relationship_kwargs={
+        "cascade": "all, delete-orphan",
+        "passive_deletes": True,
+    }
+)
+
+# Many-to-many (Theme <-> Tags) -- link table cleanup via DB cascade
+tags: List["Tag"] = Relationship(
+    back_populates="themes",
+    link_model=ThemeTag,
+    sa_relationship_kwargs={
+        "cascade": "save-update, merge",
+        "passive_deletes": True,
+    }
+)
+```
+
+## PostgreSQL Table Naming
+- Explicitly set `__tablename__` for join tables to follow snake_case convention
+- Example: `__tablename__ = "theme_tag"` (not auto-generated "themetag")
+- Improves readability in psql and aligns with PostgreSQL conventions


### PR DESCRIPTION
## What

Commits `docs/data-model.md`, `docs/digests.md`, and `docs/solutions/cascade-patterns.md`. All three are linked from CLAUDE.md's "Deep-Dive References" section but were never tracked, so a fresh clone (or any agent session following those pointers) hit missing files.

## Verification

Each file was checked against the code rather than committed blind:

- `digests.md` — `app/digest/` (generate, email, send, routes) and `app/scheduler.py` exist as described; `Digest`, `DigestType`, `Subscriber`, `DigestSend` all present in `app/models.py`.
- `cascade-patterns.md` — the `all, delete-orphan` / `save-update, merge` split and `passive_deletes` usage match the actual `sa_relationship_kwargs` in `app/models.py`. The `__tablename__ = "theme_tag"` snake_case claim holds.
- `data-model.md` — model fields and relationships match. One gap found and fixed: `Tag.position` (`app/models.py:180`) backs the tag drag-to-reorder feature and was missing from the doc.

Docs only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)