### PR TITLE
docs: record the Actions deploy pipeline now that it is live

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,29 @@ uv 0.8.12. `railway.toml` sets `builder = "dockerfile"`; there is no `nixpacks.t
   `DATABASE_URL`, `R2_*`, `ANTHROPIC_API_KEY`, `REPLICATE_API_TOKEN`, `JWT_SECRET`,
   `ADMIN_PASSWORD`. Nothing sensitive is baked into the Dockerfile.
 
+**Deploys run from GitHub Actions** (`.github/workflows/deploy.yml`), on every push to
+`main`, via `railway up --ci`. Do not deploy by hand and do not re-enable Railway's
+native git trigger.
+
+- **Why Actions and not Railway's own trigger:** a failed Railway build is silent. It
+  just keeps serving the last good deployment, which is exactly how the build stayed
+  broken in production for ~2 months. A failed Actions job is a red X on the commit,
+  where it can't be missed. Re-enabling the native trigger also double-deploys.
+- **`RAILWAY_TOKEN` is a project token scoped to the production environment.** Doppler
+  is the system of record (`breadcrumbs` / `prd`); GitHub Actions secrets hold the
+  working copy, because `secrets.*` cannot read from Doppler. To rotate, mint a new
+  token in the Railway dashboard (browser-only, the CLI has no `tokens` subcommand),
+  then update both:
+  ```bash
+  pbpaste | doppler secrets set RAILWAY_TOKEN -p breadcrumbs -c prd --silent
+  doppler secrets get RAILWAY_TOKEN -p breadcrumbs -c prd --plain \
+    | gh secret set RAILWAY_TOKEN --repo meninoebom/breadcrumbs
+  ```
+- **Validating a project token:** `railway whoami` returns `Unauthorized` even for a
+  good project token, because a project token is not tied to a user. That is a false
+  negative. Test with a project-scoped call instead, e.g.
+  `railway variables --service "Breadcrumbs Web App Server"`.
+
 ## Development Workflow
 
 **Tracking what's next:**

--- a/docs/solutions/deployment-gotchas.md
+++ b/docs/solutions/deployment-gotchas.md
@@ -50,8 +50,11 @@ build leaves the previous deployment serving, with no signal in GitHub. Two defe
 
 - After merging anything that touches the build, confirm a new deployment actually
   went live (check the Railway dashboard, or `railway deployment list`).
-- Consider enabling Railway deploy-failure notifications, or a GitHub Actions deploy
-  job, so a failed deploy surfaces where the team already looks.
+- **Fixed 2026-07-25:** deploys now run from `.github/workflows/deploy.yml` on push to
+  `main`, so a failed deploy is a red X on the commit instead of silence. Railway's
+  native git trigger stays disconnected on purpose; re-enabling it would both restore
+  the silent-failure mode and cause double deploys. See the deploy section of
+  `CLAUDE.md` for the token setup and rotation steps.
 
 ## `railway up` from an unlinked directory creates a new project
 


### PR DESCRIPTION
## What

#97 shipped `.github/workflows/deploy.yml`, but no doc described the resulting pipeline. `docs/solutions/deployment-gotchas.md` still listed "consider ... a GitHub Actions deploy job" as a future suggestion, which is now stale.

## Adds

- **CLAUDE.md, deploy section** — deploys run from Actions on push to `main`; don't deploy by hand; don't re-enable Railway's native trigger (it restores the silent-failure mode *and* double-deploys).
- **Where `RAILWAY_TOKEN` lives** — Doppler `breadcrumbs`/`prd` is the system of record, GitHub Actions secrets hold the working copy. They are mirrored rather than one sourcing the other because `secrets.*` cannot read from Doppler; routing through Doppler would require a Doppler service token stored as a GitHub secret, which is circular. Rotation commands included.
- **A false negative worth writing down** — `railway whoami` returns `Unauthorized` for a perfectly valid project token, because a project token isn't tied to a user. This briefly looked like a bad token during setup. The real check is a project-scoped call such as `railway variables --service "Breadcrumbs Web App Server"`.
- **deployment-gotchas.md** — marks the silent-deploy-failure problem as fixed 2026-07-25 and points at CLAUDE.md for the token setup.

## Verified

First Actions-driven deploy ran green on the #97 merge (run `30183684032`, 46s) and produced Railway deployment `672231e0`, now Online with `/`, `/api/themes`, `/api/tags` all 200.

## Noted, not changed

`deploy.yml` has no `paths-ignore`, so this docs-only PR will itself trigger a full Docker build and redeploy. Worth adding a docs-only skip, but that's a behavior change and belongs in its own PR.

Docs only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)